### PR TITLE
feat: E10 session discovery & resume

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,45 @@ impl Config {
             .map_err(|e| miette::miette!("Error al cargar configuración: {}. Crea un 'backscroll.toml' o configura BACKSCROLL_DATABASE_PATH.", e))
     }
 
+    #[expect(dead_code, reason = "will be integrated in T055")]
+    pub fn discover_session_dirs() -> Vec<PathBuf> {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        let projects_dir = PathBuf::from(&home).join(".claude/projects");
+
+        if !projects_dir.is_dir() {
+            tracing::info!(
+                "No Claude projects directory found at {}",
+                projects_dir.display()
+            );
+            return Vec::new();
+        }
+
+        let dirs: Vec<PathBuf> = std::fs::read_dir(&projects_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+
+        if dirs.is_empty() {
+            tracing::info!(
+                "No session directories found under {}",
+                projects_dir.display()
+            );
+        } else {
+            tracing::info!(
+                "Discovered {} session directories: {:?}",
+                dirs.len(),
+                dirs.iter()
+                    .map(|d| d.display().to_string())
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        dirs
+    }
+
     pub fn default_with_paths() -> Self {
         let mut db_path = PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()));
         db_path.push(".backscroll.db");

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,6 @@ impl Config {
             .map_err(|e| miette::miette!("Error al cargar configuración: {}. Crea un 'backscroll.toml' o configura BACKSCROLL_DATABASE_PATH.", e))
     }
 
-    #[expect(dead_code, reason = "will be integrated in T055")]
     pub fn discover_session_dirs() -> Vec<PathBuf> {
         let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
         let projects_dir = PathBuf::from(&home).join(".claude/projects");

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,10 @@ impl Config {
     pub fn discover_session_dirs() -> Vec<PathBuf> {
         let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
         let projects_dir = PathBuf::from(&home).join(".claude/projects");
+        Self::discover_session_dirs_from(&projects_dir)
+    }
 
+    pub fn discover_session_dirs_from(projects_dir: &std::path::Path) -> Vec<PathBuf> {
         if !projects_dir.is_dir() {
             tracing::info!(
                 "No Claude projects directory found at {}",
@@ -67,7 +70,7 @@ impl Config {
             return Vec::new();
         }
 
-        let dirs: Vec<PathBuf> = std::fs::read_dir(&projects_dir)
+        let dirs: Vec<PathBuf> = std::fs::read_dir(projects_dir)
             .into_iter()
             .flatten()
             .filter_map(|entry| entry.ok())
@@ -108,6 +111,7 @@ impl Config {
 mod tests {
     use super::*;
     use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_config_load_error_if_missing() {
@@ -174,5 +178,39 @@ mod tests {
             .extract()
             .unwrap();
         assert_eq!(config.session_dirs, vec!["."]);
+    }
+
+    #[test]
+    fn test_discover_finds_project_dirs() {
+        let root = tempdir().unwrap();
+        let projects = root.path().join(".claude/projects");
+        fs::create_dir_all(projects.join("project-a")).unwrap();
+        fs::create_dir_all(projects.join("project-b")).unwrap();
+        // Create a file (should be ignored, only dirs)
+        fs::write(projects.join("not-a-dir.txt"), "").unwrap();
+
+        let dirs = Config::discover_session_dirs_from(&projects);
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.iter().any(|d| d.ends_with("project-a")));
+        assert!(dirs.iter().any(|d| d.ends_with("project-b")));
+    }
+
+    #[test]
+    fn test_discover_empty_when_no_projects() {
+        let root = tempdir().unwrap();
+        let projects = root.path().join(".claude/projects");
+        fs::create_dir_all(&projects).unwrap();
+
+        let dirs = Config::discover_session_dirs_from(&projects);
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn test_discover_empty_when_dir_missing() {
+        let root = tempdir().unwrap();
+        let nonexistent = root.path().join("nope");
+
+        let dirs = Config::discover_session_dirs_from(&nonexistent);
+        assert!(dirs.is_empty());
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,4 +42,5 @@ pub trait SearchEngine {
     fn search(&self, query: &str, project: &Option<String>) -> miette::Result<Vec<SearchResult>>;
     fn get_file_hashes(&self) -> miette::Result<HashMap<String, String>>;
     fn get_stats(&self) -> miette::Result<Stats>;
+    fn get_session_id(&self, source_path: &str) -> miette::Result<Option<String>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,17 @@ fn create_engine(config: &Config) -> Result<Box<dyn SearchEngine>> {
     Ok(Box::new(db))
 }
 
+fn extract_session_id(source_path: &str) -> String {
+    // Extract UUID-like session ID from path like:
+    // ~/.claude/projects/-opt-foo/04df2262-a48e-4549-97a9-11bcf4bb0257/session.jsonl
+    std::path::Path::new(source_path)
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .find(|s| s.len() >= 32 && s.contains('-'))
+        .unwrap_or(source_path)
+        .to_string()
+}
+
 fn resolve_session_paths(cli_paths: &[String], config: &Config) -> Result<Vec<String>> {
     // 1. CLI --path overrides everything
     if !cli_paths.is_empty() {
@@ -226,17 +237,19 @@ fn main() -> Result<()> {
 
             let results = engine.search(query, &effective_project)?;
             if let Some(result) = results.first() {
+                let session_id = extract_session_id(&result.source_path);
                 if *robot {
-                    println!("{}", result.source_path);
+                    println!("{}\t{}", session_id, result.source_path);
                 } else {
                     println!("Session: {}", result.source_path);
-                    println!("Score: {:.2}", result.score);
+                    println!("ID: {}", session_id);
                     if let Some(snippet) = &result.match_snippet {
                         println!("Match: {}", snippet);
                     }
                 }
             } else {
-                println!("No matching session found.");
+                eprintln!("No matching session found.");
+                std::process::exit(1);
             }
         }
         Commands::Status => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,17 @@ enum Commands {
         /// Ruta al archivo JSONL de la sesión
         path: std::path::PathBuf,
     },
+    /// Buscar y retornar la sesión más reciente para --resume
+    Resume {
+        /// Consulta de búsqueda
+        query: String,
+        /// Filtrar por proyecto
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Formato compacto tab-separated
+        #[arg(long, default_value_t = false)]
+        robot: bool,
+    },
     /// Mostrar estado del índice
     Status,
 }
@@ -187,6 +198,45 @@ fn main() -> Result<()> {
                 println!("[{}]", msg.role);
                 println!("{}", msg.text);
                 println!();
+            }
+        }
+        Commands::Resume {
+            query,
+            project,
+            robot,
+        } => {
+            let engine = create_engine(&config)?;
+
+            // Auto-sync before resume search
+            if let Ok(paths) = resolve_session_paths(&[], &config) {
+                for p in &paths {
+                    let hashes = engine.get_file_hashes()?;
+                    let files = parse_sessions(p, &hashes, false)?;
+                    if !files.is_empty() {
+                        engine.sync_files(files)?;
+                    }
+                }
+            }
+
+            let effective_project = project.clone().or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|p| p.to_string_lossy().replace('/', "-"))
+            });
+
+            let results = engine.search(query, &effective_project)?;
+            if let Some(result) = results.first() {
+                if *robot {
+                    println!("{}", result.source_path);
+                } else {
+                    println!("Session: {}", result.source_path);
+                    println!("Score: {:.2}", result.score);
+                    if let Some(snippet) = &result.match_snippet {
+                        println!("Match: {}", snippet);
+                    }
+                }
+            } else {
+                println!("No matching session found.");
             }
         }
         Commands::Status => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,32 @@ fn create_engine(config: &Config) -> Result<Box<dyn SearchEngine>> {
     Ok(Box::new(db))
 }
 
+fn resolve_session_paths(cli_paths: &[String], config: &Config) -> Result<Vec<String>> {
+    // 1. CLI --path overrides everything
+    if !cli_paths.is_empty() {
+        return Ok(cli_paths.to_vec());
+    }
+
+    // 2. Non-default config takes precedence
+    if config.session_dirs != vec!["."] {
+        return Ok(config.session_dirs.clone());
+    }
+
+    // 3. Auto-discovery fallback
+    let discovered = Config::discover_session_dirs();
+    if !discovered.is_empty() {
+        return Ok(discovered
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect());
+    }
+
+    // 4. No paths found
+    Err(miette::miette!(
+        "No session directories found. Use --path, configure session_dirs in backscroll.toml, or ensure ~/.claude/projects/ exists."
+    ))
+}
+
 use tracing_subscriber::EnvFilter;
 
 fn main() -> Result<()> {
@@ -87,13 +113,9 @@ fn main() -> Result<()> {
             path,
             include_agents,
         } => {
-            let paths = if path.is_empty() {
-                &config.session_dirs
-            } else {
-                path
-            };
+            let paths = resolve_session_paths(path, &config)?;
             let engine = create_engine(&config)?;
-            for p in paths {
+            for p in &paths {
                 println!("Sincronizando sesiones desde: {}", p);
                 let hashes = engine.get_file_hashes()?;
                 let files = parse_sessions(p, &hashes, *include_agents)?;
@@ -112,11 +134,13 @@ fn main() -> Result<()> {
             let engine = create_engine(&config)?;
 
             // Auto-sync: indexar sesiones nuevas antes de buscar (incremental, rápido)
-            for p in &config.session_dirs {
-                let hashes = engine.get_file_hashes()?;
-                let files = parse_sessions(p, &hashes, false)?;
-                if !files.is_empty() {
-                    engine.sync_files(files)?;
+            if let Ok(paths) = resolve_session_paths(&[], &config) {
+                for p in &paths {
+                    let hashes = engine.get_file_hashes()?;
+                    let files = parse_sessions(p, &hashes, false)?;
+                    if !files.is_empty() {
+                        engine.sync_files(files)?;
+                    }
                 }
             }
 
@@ -172,11 +196,13 @@ fn main() -> Result<()> {
 
             if let Ok(engine) = create_engine(&config) {
                 // Auto-sync antes de mostrar stats
-                for p in &config.session_dirs {
-                    if let Ok(hashes) = engine.get_file_hashes() {
-                        if let Ok(files) = parse_sessions(p, &hashes, false) {
-                            if !files.is_empty() {
-                                let _ = engine.sync_files(files);
+                if let Ok(paths) = resolve_session_paths(&[], &config) {
+                    for p in &paths {
+                        if let Ok(hashes) = engine.get_file_hashes() {
+                            if let Ok(files) = parse_sessions(p, &hashes, false) {
+                                if !files.is_empty() {
+                                    let _ = engine.sync_files(files);
+                                }
                             }
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,9 @@ enum Commands {
         /// Filtrar por proyecto
         #[arg(short, long)]
         project: Option<String>,
+        /// Buscar en todos los proyectos
+        #[arg(long, default_value_t = false)]
+        all_projects: bool,
         /// Formato compacto tab-separated
         #[arg(long, default_value_t = false)]
         robot: bool,
@@ -214,6 +217,7 @@ fn main() -> Result<()> {
         Commands::Resume {
             query,
             project,
+            all_projects,
             robot,
         } => {
             let engine = create_engine(&config)?;
@@ -229,11 +233,15 @@ fn main() -> Result<()> {
                 }
             }
 
-            let effective_project = project.clone().or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .map(|p| p.to_string_lossy().replace('/', "-"))
-            });
+            let effective_project = if *all_projects {
+                None
+            } else {
+                project.clone().or_else(|| {
+                    std::env::current_dir()
+                        .ok()
+                        .map(|p| p.to_string_lossy().replace('/', "-"))
+                })
+            };
 
             let results = engine.search(query, &effective_project)?;
             if let Some(result) = results.first() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,17 +84,6 @@ fn create_engine(config: &Config) -> Result<Box<dyn SearchEngine>> {
     Ok(Box::new(db))
 }
 
-fn extract_session_id(source_path: &str) -> String {
-    // Extract UUID-like session ID from path like:
-    // ~/.claude/projects/-opt-foo/04df2262-a48e-4549-97a9-11bcf4bb0257/session.jsonl
-    std::path::Path::new(source_path)
-        .components()
-        .filter_map(|c| c.as_os_str().to_str())
-        .find(|s| s.len() >= 32 && s.contains('-'))
-        .unwrap_or(source_path)
-        .to_string()
-}
-
 fn resolve_session_paths(cli_paths: &[String], config: &Config) -> Result<Vec<String>> {
     // 1. CLI --path overrides everything
     if !cli_paths.is_empty() {
@@ -245,7 +234,9 @@ fn main() -> Result<()> {
 
             let results = engine.search(query, &effective_project)?;
             if let Some(result) = results.first() {
-                let session_id = extract_session_id(&result.source_path);
+                let session_id = engine
+                    .get_session_id(&result.source_path)?
+                    .unwrap_or_else(|| result.source_path.clone());
                 if *robot {
                     println!("{}\t{}", session_id, result.source_path);
                 } else {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -260,6 +260,26 @@ impl SearchEngine for Database {
         Ok(hashes)
     }
 
+    fn get_session_id(&self, source_path: &str) -> miette::Result<Option<String>> {
+        let result: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT uuid FROM search_items WHERE source_path = ? AND uuid IS NOT NULL ORDER BY ordinal LIMIT 1",
+                params![source_path],
+                |row| row.get(0),
+            )
+            .ok();
+
+        // Fallback: extract file stem from path
+        Ok(Some(result.unwrap_or_else(|| {
+            std::path::Path::new(source_path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(source_path)
+                .to_string()
+        })))
+    }
+
     fn get_stats(&self) -> miette::Result<Stats> {
         let file_count: i64 = self
             .conn

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -370,4 +370,62 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_get_session_id_with_uuid() -> miette::Result<()> {
+        let db = Database::open(":memory:")?;
+        db.setup_schema()?;
+
+        let file = ParsedFile {
+            source_path: "/sessions/session.jsonl".to_string(),
+            hash: "h1".to_string(),
+            project: None,
+            messages: vec![ParsedMessage {
+                role: "user".to_string(),
+                text: "hello".to_string(),
+                ordinal: 0,
+                uuid: Some("04df2262-a48e-4549-97a9-11bcf4bb0257".to_string()),
+                timestamp: None,
+            }],
+        };
+        db.sync_files(vec![file])?;
+
+        let id = db.get_session_id("/sessions/session.jsonl")?;
+        assert_eq!(id, Some("04df2262-a48e-4549-97a9-11bcf4bb0257".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_session_id_fallback_to_stem() -> miette::Result<()> {
+        let db = Database::open(":memory:")?;
+        db.setup_schema()?;
+
+        let file = ParsedFile {
+            source_path: "/sessions/my-session.jsonl".to_string(),
+            hash: "h2".to_string(),
+            project: None,
+            messages: vec![ParsedMessage {
+                role: "user".to_string(),
+                text: "no uuid here".to_string(),
+                ordinal: 0,
+                uuid: None,
+                timestamp: None,
+            }],
+        };
+        db.sync_files(vec![file])?;
+
+        let id = db.get_session_id("/sessions/my-session.jsonl")?;
+        assert_eq!(id, Some("my-session".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_session_id_nonexistent_path() -> miette::Result<()> {
+        let db = Database::open(":memory:")?;
+        db.setup_schema()?;
+
+        let id = db.get_session_id("/does/not/exist.jsonl")?;
+        assert_eq!(id, Some("exist".to_string()));
+        Ok(())
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -116,3 +116,97 @@ fn test_parse_real_jsonl() {
         .success()
         .stdout(predicate::str::contains("mundo"));
 }
+
+fn sync_fixture(session_dir: &std::path::Path, db_path: &std::path::Path) {
+    let session_file = session_dir.join("session.jsonl");
+    fs::write(
+        &session_file,
+        r#"{"type": "user", "message": {"role": "user", "content": "deploy kubernetes cluster"}, "uuid": "r1", "timestamp": "100"}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("backscroll")
+        .unwrap()
+        .arg("sync")
+        .arg("--path")
+        .arg(session_dir.to_str().unwrap())
+        .env("BACKSCROLL_DATABASE_PATH", db_path.to_str().unwrap())
+        .env("BACKSCROLL_SESSION_DIR", session_dir.to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_resume_text_output() {
+    let session_dir = tempdir().unwrap();
+    let db_dir = tempdir().unwrap();
+    let db_path = db_dir.path().join("resume_text.db");
+    sync_fixture(session_dir.path(), &db_path);
+
+    Command::cargo_bin("backscroll")
+        .unwrap()
+        .arg("resume")
+        .arg("kubernetes")
+        .arg("--all-projects")
+        .env("BACKSCROLL_DATABASE_PATH", db_path.to_str().unwrap())
+        .env(
+            "BACKSCROLL_SESSION_DIR",
+            session_dir.path().to_str().unwrap(),
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Session:"))
+        .stdout(predicate::str::contains("ID:"));
+}
+
+#[test]
+fn test_resume_robot_output() {
+    let session_dir = tempdir().unwrap();
+    let db_dir = tempdir().unwrap();
+    let db_path = db_dir.path().join("resume_robot.db");
+    sync_fixture(session_dir.path(), &db_path);
+
+    let output = Command::cargo_bin("backscroll")
+        .unwrap()
+        .arg("resume")
+        .arg("kubernetes")
+        .arg("--robot")
+        .arg("--all-projects")
+        .env("BACKSCROLL_DATABASE_PATH", db_path.to_str().unwrap())
+        .env(
+            "BACKSCROLL_SESSION_DIR",
+            session_dir.path().to_str().unwrap(),
+        )
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 1, "Robot mode should be single line");
+    assert!(
+        lines[0].contains('\t'),
+        "Robot mode should be tab-separated"
+    );
+}
+
+#[test]
+fn test_resume_no_results_exit_code() {
+    let session_dir = tempdir().unwrap();
+    let db_dir = tempdir().unwrap();
+    let db_path = db_dir.path().join("resume_noresult.db");
+    sync_fixture(session_dir.path(), &db_path);
+
+    Command::cargo_bin("backscroll")
+        .unwrap()
+        .arg("resume")
+        .arg("xyznonexistent999")
+        .arg("--all-projects")
+        .env("BACKSCROLL_DATABASE_PATH", db_path.to_str().unwrap())
+        .env(
+            "BACKSCROLL_SESSION_DIR",
+            session_dir.path().to_str().unwrap(),
+        )
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No matching session"));
+}


### PR DESCRIPTION
## Summary
- **Multi-path config**: `session_dirs` accepts string or array with backward-compatible serde deserializer (`session_dir` alias still works)
- **Auto-discovery**: `discover_session_dirs()` scans `~/.claude/projects/` for session directories; `resolve_session_paths()` implements 3-tier priority (CLI > config > discovery)
- **Resume subcommand**: `backscroll resume <query>` finds the best matching session and returns its ID for `--resume` piping; supports `--robot` for machine-readable output
- **Session ID resolution**: `SearchEngine::get_session_id()` trait method queries UUID from DB with file-stem fallback
- **Auto-sync on query**: search/resume/status commands auto-index new sessions before querying

## Test plan
- [x] `cargo test` — all 19 tests pass (9 unit + 10 integration)
- [x] `just check` — fmt, clippy, cargo check clean
- [x] Resume text/robot output verified via CLI integration tests
- [x] Resume exit code 1 on no results
- [x] Config backward compat: `session_dir = "/a"` and `session_dirs = ["/a", "/b"]` both work
- [x] Discovery finds project dirs, ignores files, handles missing dirs