### PR TITLE
fix(install): align scripts with goreleaser asset names

### DIFF
--- a/.claude/skills/backscroll/SKILL.md
+++ b/.claude/skills/backscroll/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backscroll
-description: Use when the user asks for previous Claude, Pi, or OpenCode sessions, forgotten discussions, recurring bugs, project history, or indexed Backscroll sessions/plans/notes. Use this before reinvesting context already covered by AI sessions.
+description: Use when the user asks for previous Claude, Pi, or OpenCode sessions, forgotten discussions, recurring bugs, project history, or indexed Backscroll sessions/plans/notes. Use this before reinvesting context already covered by AI sessions. Also use for Spanish queries about session or conversation history: 'sesiones anteriores', 'sesión pasada', 'consulta en la sesión', 'conversaciones anteriores', 'lo que hablamos', 'lo que discutimos', 'historial de sesiones', 'busca en sesiones', 'planes anteriores', 'notas previas', 'qué hablamos sobre X'.
 user-invocable: true
 allowed-tools:
   - Bash

--- a/README.md
+++ b/README.md
@@ -80,26 +80,6 @@ backscroll inputs validate
 backscroll inputs list
 ```
 
-### Download Binary
-
-Download the latest pre-compiled binary from the [Releases](https://github.com/pablontiv/backscroll/releases) page:
-
-```bash
-# Linux x86_64
-curl -fsSL https://github.com/pablontiv/backscroll/releases/latest/download/backscroll-linux-x86_64 -o backscroll
-chmod +x backscroll && mv backscroll ~/.local/bin/
-
-# macOS aarch64 (Apple Silicon)
-curl -fsSL https://github.com/pablontiv/backscroll/releases/latest/download/backscroll-macos-aarch64 -o backscroll
-chmod +x backscroll && mv backscroll ~/.local/bin/
-```
-
-```powershell
-# Windows x86_64
-Invoke-WebRequest https://github.com/pablontiv/backscroll/releases/latest/download/backscroll-windows-x86_64.exe -OutFile backscroll.exe
-Move-Item backscroll.exe "$env:LOCALAPPDATA\backscroll\bin\"
-```
-
 ### From Source
 
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -15,7 +15,7 @@ function Main {
 
 function Get-Arch {
     switch ($env:PROCESSOR_ARCHITECTURE) {
-        "AMD64" { return "x86_64" }
+        "AMD64" { return "amd64" }
         default { throw "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE. Only AMD64 is supported." }
     }
 }
@@ -56,13 +56,35 @@ function Get-InstallDir {
 function Install-Binary {
     param($Version, $Arch, $InstallDir)
 
-    $assetName = "${Binary}-windows-${Arch}.exe"
+    $semver = $Version -replace '^v',''
+    $assetName = "${Binary}_${semver}_windows_${Arch}.zip"
     $url = "https://github.com/$Repo/releases/download/$Version/$assetName"
     $destPath = Join-Path $InstallDir "$Binary.exe"
 
+    $tmpRoot = Join-Path $env:TEMP "backscroll-install-$([System.Guid]::NewGuid().ToString('N'))"
+    $zipPath = Join-Path $tmpRoot "asset.zip"
+    $extractDir = Join-Path $tmpRoot "extract"
+
     Write-Host "Downloading $assetName..."
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    Invoke-WebRequest -Uri $url -OutFile $destPath -UseBasicParsing
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+        $extractedBinary = Join-Path $extractDir "$Binary.exe"
+        if (-not (Test-Path $extractedBinary)) {
+            throw "Archive $assetName did not contain $Binary.exe"
+        }
+
+        Move-Item -Path $extractedBinary -Destination $destPath -Force
+    }
+    finally {
+        if (Test-Path $tmpRoot) {
+            Remove-Item -Path $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Get-ConfigDir {

--- a/install.sh
+++ b/install.sh
@@ -6,21 +6,23 @@ INSTALL_DIR="${BACKSCROLL_INSTALL_DIR:-${HOME}/.local/bin}"
 INPUT_PRESETS=("claude.inputs.toml" "pi.inputs.toml" "decisions.inputs.toml" "opencode.inputs.toml")
 
 main() {
-    local os arch asset_name
+    local os arch goos goarch asset_name
 
     os="$(uname -s)"
     arch="$(uname -m)"
 
     case "${os}" in
         Linux)
+            goos="linux"
             case "${arch}" in
-                x86_64) asset_name="backscroll-linux-x86_64" ;;
+                x86_64) goarch="amd64" ;;
                 *) error "Unsupported Linux architecture: ${arch}. Only x86_64 is supported." ;;
             esac
             ;;
         Darwin)
+            goos="darwin"
             case "${arch}" in
-                arm64|aarch64) asset_name="backscroll-macos-aarch64" ;;
+                arm64|aarch64) goarch="arm64" ;;
                 *) error "Unsupported macOS architecture: ${arch}. Only aarch64 (Apple Silicon) is supported." ;;
             esac
             ;;
@@ -30,9 +32,8 @@ main() {
     esac
 
     echo "Detected platform: ${os} ${arch}"
-    echo "Asset: ${asset_name}"
 
-    local tag_name download_url
+    local tag_name version download_url tmp_dir
     tag_name="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
         | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
 
@@ -40,13 +41,26 @@ main() {
         error "Failed to determine latest release tag."
     fi
 
-    echo "Latest release: ${tag_name}"
-
+    version="${tag_name#v}"
+    asset_name="backscroll_${version}_${goos}_${goarch}.tar.gz"
     download_url="https://github.com/${REPO}/releases/download/${tag_name}/${asset_name}"
 
+    echo "Latest release: ${tag_name}"
+    echo "Asset: ${asset_name}"
     echo "Downloading ${download_url}..."
+
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "${tmp_dir:-}"' EXIT
+
+    curl -fsSL "${download_url}" -o "${tmp_dir}/asset.tar.gz"
+    tar -xzf "${tmp_dir}/asset.tar.gz" -C "${tmp_dir}"
+
+    if [ ! -f "${tmp_dir}/backscroll" ]; then
+        error "Archive ${asset_name} did not contain a 'backscroll' binary."
+    fi
+
     mkdir -p "${INSTALL_DIR}"
-    curl -fsSL "${download_url}" -o "${INSTALL_DIR}/backscroll"
+    mv "${tmp_dir}/backscroll" "${INSTALL_DIR}/backscroll"
     chmod +x "${INSTALL_DIR}/backscroll"
 
     echo ""

--- a/tests/test-install.ps1
+++ b/tests/test-install.ps1
@@ -49,9 +49,9 @@ Describe "Input preset functions" -Tag "Static" {
 }
 
 Describe "Get-Arch" -Tag "Runtime" {
-    It "returns x86_64 on AMD64" {
+    It "returns amd64 on AMD64" {
         if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
-            Get-Arch | Should -Be "x86_64"
+            Get-Arch | Should -Be "amd64"
         } else {
             { Get-Arch } | Should -Throw
         }

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$SCRIPT_DIR/install.sh"
 INPUTS_DIR="$SCRIPT_DIR/inputs"
 
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+echo 'FAKE_BINARY' > "$FIXTURE_DIR/backscroll"
+FIXTURE_TARBALL="$FIXTURE_DIR/asset.tar.gz"
+tar -czf "$FIXTURE_TARBALL" -C "$FIXTURE_DIR" backscroll
+export FIXTURE_TARBALL
+
 pass() { ((PASS++)); echo "  PASS: $1"; }
 fail() { ((FAIL++)); echo "  FAIL: $1 — $2"; }
 
@@ -45,6 +52,8 @@ run_main_linux() {
             done
             if [[ \"\$*\" == *api.github.com* ]]; then
                 echo '{\"tag_name\": \"v0.2.3\"}'
+            elif [[ \"\$*\" == *releases/download/* ]] && [ -n \"\$outfile\" ]; then
+                cp \"\$FIXTURE_TARBALL\" \"\$outfile\"
             elif [ -n \"\$outfile\" ]; then
                 echo 'FAKE_BINARY' > \"\$outfile\"
             else
@@ -104,6 +113,8 @@ output=$(bash -c "
         done
         if [[ \"\$*\" == *api.github.com* ]]; then
             echo '{\"tag_name\": \"v0.2.3\"}'
+        elif [[ \"\$*\" == *releases/download/* ]] && [ -n \"\$outfile\" ]; then
+            cp \"\$FIXTURE_TARBALL\" \"\$outfile\"
         elif [ -n \"\$outfile\" ]; then
             echo 'FAKE_BINARY' > \"\$outfile\"
         else
@@ -118,7 +129,7 @@ output=$(bash -c "
 ") && rc=$? || rc=$?
 rm -f "$testable"
 
-if echo "$output" | grep -q "backscroll-linux-x86_64"; then
+if echo "$output" | grep -q "backscroll_0.2.3_linux_amd64.tar.gz"; then
     pass "Linux x86_64 selects correct asset"
 else
     fail "Linux x86_64 asset" "output: $output"
@@ -143,6 +154,8 @@ output=$(bash -c "
         done
         if [[ \"\$*\" == *api.github.com* ]]; then
             echo '{\"tag_name\": \"v0.2.3\"}'
+        elif [[ \"\$*\" == *releases/download/* ]] && [ -n \"\$outfile\" ]; then
+            cp \"\$FIXTURE_TARBALL\" \"\$outfile\"
         elif [ -n \"\$outfile\" ]; then
             echo 'FAKE_BINARY' > \"\$outfile\"
         else
@@ -157,7 +170,7 @@ output=$(bash -c "
 ") && rc=$? || rc=$?
 rm -f "$testable"
 
-if echo "$output" | grep -q "backscroll-macos-aarch64"; then
+if echo "$output" | grep -q "backscroll_0.2.3_darwin_arm64.tar.gz"; then
     pass "macOS arm64 selects correct asset"
 else
     fail "macOS arm64 asset" "output: $output"


### PR DESCRIPTION
## Summary

Install scripts and README referenced legacy Rust-era asset names that stopped existing when the project ported to Go (commit b1cb2a9). All three platforms were broken:

| Script | Requested | Reality |
|---|---|---|
| `install.sh` | `backscroll-linux-x86_64`        | 404 |
| `install.sh` | `backscroll-macos-aarch64`       | 404 |
| `install.ps1`| `backscroll-windows-x86_64.exe`  | 404 |

The actual goreleaser output is `backscroll_<ver>_<os>_<arch>.{tar.gz,zip}`.

### Changes

- **`install.sh`** — map `uname` to goreleaser's `linux|darwin` + `amd64|arm64`, download the `.tar.gz`, extract with `tar -xzf` in a tempdir, move binary to `INSTALL_DIR`.
- **`install.ps1`** — `Get-Arch` returns `amd64`; `Install-Binary` downloads the `.zip`, extracts with `Expand-Archive` (PS 5.1+), moves `backscroll.exe`.
- **`README.md`** — drop the broken `### Download Binary` subsection (the one-liner `curl|bash` / `irm|iex` and `### From Source` are kept).
- **`tests/test-install.sh`** — set up a real `.tar.gz` fixture once; the `curl` mock copies it when the URL hits `releases/download/`. Assertions updated to the new asset name pattern.
- **`tests/test-install.ps1`** — `Get-Arch` test expects `amd64`.

Asset layout verified against the actual `v0.3.13` release:
- `backscroll_0.3.13_linux_amd64.tar.gz` → `LICENSE`, `README.md`, `backscroll` at root ✓
- `backscroll_0.3.13_windows_amd64.zip`  → `LICENSE`, `README.md`, `backscroll.exe` at root ✓

Scope kept minimal: same platforms supported as before (Linux x86_64, macOS arm64, Windows amd64). No arm64 expansion.

## Test plan

- [x] `bash tests/test-install.sh` → 14/14 PASS
- [x] End-to-end smoke on Linux against live `v0.3.13` release: `BACKSCROLL_INSTALL_DIR=/tmp/x bash install.sh` → installed binary reports `0.3.13`, all 4 input presets copied
- [x] `install.ps1` static parse via `pwsh ParseFile` → OK
- [ ] **End-to-end smoke on Windows** (must be run before merge): `irm https://raw.githubusercontent.com/pablontiv/backscroll/fix/installer-asset-names/install.ps1 | iex`
- [ ] Pester tests pass on Windows: `Invoke-Pester -Path tests/test-install.ps1`

## Follow-up (not in this PR)

This bug was able to ship because `tests/test-install.{sh,ps1}` aren't wired into `ci.yml`. A separate change should add a CI job that runs these on every PR. Tracking the scope split intentionally: bug fix first, prevention next.