### PR TITLE
fix: recovered index immediately fails validate as orphaned

### DIFF
--- a/cmd/backscroll/recover_test.go
+++ b/cmd/backscroll/recover_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -211,6 +212,78 @@ func TestRecoverApplyReportsActualBackupAndCounts(t *testing.T) {
 	}
 }
 
+func TestRecoverInstalledDestinationPassesIndexedValidation(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	activePath := filepath.Join(dir, "active.db")
+	strandedPath := filepath.Join(dir, "stranded.db")
+	createRecoverFixtureDB(t, activePath, "active-v13.sql", map[string]string{
+		"uuid-active-v13": "11111111-1111-4111-8111-111111111111",
+	})
+	createRecoverFixtureDB(t, strandedPath, "stranded-v7.sql", map[string]string{
+		"uuid-stranded-v7": "22222222-2222-4222-8222-222222222222",
+	})
+	activeBefore, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("BACKSCROLL_CONFIG_DIR", filepath.Join(dir, "config"))
+	t.Setenv("BACKSCROLL_DATABASE_PATH", activePath)
+	t.Chdir(dir)
+
+	var recoverOut, recoverErr bytes.Buffer
+	recoverCmd := buildRootCmd(&recoverOut, &recoverErr)
+	recoverCmd.SetArgs([]string{"recover", "--from", strandedPath})
+	if err := recoverCmd.Execute(); err != nil {
+		t.Fatalf("recover: %v\nstderr=%s", err, recoverErr.String())
+	}
+	if recoverErr.String() != "" {
+		t.Fatalf("recover stderr = %q, want empty", recoverErr.String())
+	}
+	backupPath := recoverOutputValue(t, recoverOut.String(), "backup path: ")
+	backupBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(backupBytes, activeBefore) {
+		t.Fatal("active backup differs from pre-recovery database")
+	}
+
+	var validateOut, validateErr bytes.Buffer
+	validateCmd := buildRootCmd(&validateOut, &validateErr)
+	validateCmd.SetArgs([]string{"validate", "--indexed-only"})
+	if err := validateCmd.Execute(); err != nil {
+		t.Fatalf("validate recovered destination: %v\nstdout=%s\nstderr=%s", err, validateOut.String(), validateErr.String())
+	}
+	if validateErr.String() != "" {
+		t.Fatalf("validate stderr = %q, want empty", validateErr.String())
+	}
+
+	db, err := storage.OpenReadOnly(activePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var records, accountedPaths, ftsHits int
+	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM search_items`).Scan(&records); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM indexed_files`).Scan(&accountedPaths); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'default'`).Scan(&ftsHits); err != nil {
+		t.Fatal(err)
+	}
+	if records != 4 || accountedPaths != 4 || ftsHits != 2 {
+		t.Fatalf("recovered database counts records=%d paths=%d fts=%d, want 4/4/2", records, accountedPaths, ftsHits)
+	}
+}
+
 func TestRecoverCommandReturnsStructuredApplyFailure(t *testing.T) {
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
@@ -376,6 +449,30 @@ func TestRecoverHasNoGeneralMergeFlags(t *testing.T) {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
 			}
 		})
+	}
+}
+
+func createRecoverFixtureDB(t *testing.T, path, fixture string, replacements map[string]string) {
+	t.Helper()
+	fixturePath := filepath.Join("..", "..", "tests", "fixtures", "recovery", fixture)
+	body, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read recovery fixture %s: %v", fixturePath, err)
+	}
+	sqlText := string(body)
+	for from, to := range replacements {
+		sqlText = strings.ReplaceAll(sqlText, from, to)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open recovery fixture %s: %v", path, err)
+	}
+	if _, err := db.Exec(sqlText); err != nil {
+		_ = db.Close()
+		t.Fatalf("execute recovery fixture %s: %v", fixture, err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close recovery fixture %s: %v", path, err)
 	}
 }
 

--- a/docs/superpowers/plans/2026-08-19-recovered-source-accounting.md
+++ b/docs/superpowers/plans/2026-08-19-recovered-source-accounting.md
@@ -1,0 +1,719 @@
+# Recovered Source Accounting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every successfully recovered database pass public validation while preserving backfill eligibility and forcing any still-present source to be genuinely re-synced.
+
+**Architecture:** Recovery writes one provisional `indexed_files` row per distinct recovered `source_path`, using the reserved non-SHA marker `backscroll:recovered` and a NULL `last_indexed`. Recovery verification requires an exact marker set; hash- and status-oriented consumers exclude markers, backfill includes them, and the existing `SyncFiles` upsert replaces a marker with a real hash.
+
+**Tech Stack:** Go, cobra command tests, `database/sql`, modernc.org/sqlite, SQLite FTS5, stdlib `testing`.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-recovered-source-accounting-design.md`
+
+## Global Constraints
+
+- Recovery reconstructs database state only; it must never create, restore, read, or modify original JSONL or Markdown source files.
+- The provisional hash value is exactly `backscroll:recovered` and must never look like a 64-character hexadecimal SHA-256.
+- Provisional rows use `NULL` for `last_indexed`.
+- Public validation must continue rejecting genuine `search_items` rows with no matching accounting path.
+- Recovered paths remain eligible for `BackfillDerived()`.
+- `GetFileHashes()` and `GetStats()` must not treat provisional rows as sources indexed from disk.
+- A normal `SyncFiles()` call must replace provisional accounting with the real hash in the same transaction as the synced records.
+- Do not add a migration or change the SQLite schema.
+- Preserve deterministic recovery output, canonical records, FTS queryability, atomic installation, and byte-identical active backup behavior.
+
+## File Structure
+
+- Create `internal/storage/recovery_accounting.go`: owns the reserved marker and the predicate that identifies provisional source accounting.
+- Modify `internal/storage/recovery_destination.go`: writes deterministic provisional accounting and verifies its exact committed shape.
+- Modify `internal/storage/recovery_destination_test.go`: pins marker creation, NULL timestamp, exact-path verification, and tamper rejection.
+- Modify `internal/storage/sync.go`: excludes provisional markers from the autosync hash skip map; normal sync upsert remains the transition mechanism.
+- Modify `internal/storage/queries.go`: excludes provisional markers from file-count and last-indexed statistics.
+- Modify `internal/storage/backfill.go`: treats provisional markers like missing/expired source accounting.
+- Modify `internal/storage/storage_test.go`: tests hash-map filtering, status filtering, and replacement by normal sync.
+- Modify `internal/storage/backfill_test.go`: proves marked recovered paths remain eligible for derived-data backfill.
+- Modify `cmd/backscroll/recover_test.go`: adds the end-to-end v13 + v7 recovery-to-validation regression and verifies backup/rows/FTS.
+
+---
+
+### Task 1: Write and verify provisional recovery accounting
+
+**Files:**
+- Create: `internal/storage/recovery_accounting.go`
+- Modify: `internal/storage/recovery_destination.go:116-136, 230-305`
+- Test: `internal/storage/recovery_destination_test.go:330-460, 660-725`
+
+**Interfaces:**
+- Consumes: `compat.RecoveryPlan`, `compat.CanonicalRecord.Record.SourcePath`, the existing recovery transaction, and `compat.Queryer`.
+- Produces: `const recoveredSourceHash = "backscroll:recovered"`, `func isRecoveredSourceHash(string) bool`, `func recoveryDestinationSourcePaths(compat.RecoveryPlan) []string`, `func insertRecoveryDestinationAccounting(context.Context, *sql.Tx, compat.RecoveryPlan) error`, and exact accounting checks inside `verifyRecoveryDestinationRows`.
+
+- [ ] **Step 1: Add failing destination-creation assertions**
+
+Update `TestRecoveryDestinationStartsFreshAtCurrentSchema` and `assertRecoveryDestinationRecords` so they expect one marker per distinct planned path instead of zero `indexed_files` rows. Use a query that also verifies `last_indexed` is NULL:
+
+```go
+rows, err := db.DB().Query(`
+    SELECT path, hash, last_indexed
+    FROM indexed_files
+    ORDER BY path
+`)
+if err != nil {
+    t.Fatalf("query recovered source accounting: %v", err)
+}
+defer func() { _ = rows.Close() }()
+
+var gotPaths []string
+for rows.Next() {
+    var path, hash string
+    var lastIndexed sql.NullString
+    if err := rows.Scan(&path, &hash, &lastIndexed); err != nil {
+        t.Fatalf("scan recovered source accounting: %v", err)
+    }
+    if hash != recoveredSourceHash || lastIndexed.Valid {
+        t.Fatalf("accounting for %s = hash %q last_indexed %+v", path, hash, lastIndexed)
+    }
+    gotPaths = append(gotPaths, path)
+}
+```
+
+Build `wantPaths` from the plan's distinct `SourcePath` values, sort it, and compare with `reflect.DeepEqual(gotPaths, wantPaths)`. Add `database/sql` to the test imports if it is not already present.
+
+- [ ] **Step 2: Add failing tamper cases for missing and incorrect accounting**
+
+Add a table-driven test next to `TestRecoveryDestinationIndependentVerificationRejectsTamper`:
+
+```go
+func TestRecoveryDestinationVerificationRejectsInvalidRecoveredAccounting(t *testing.T) {
+    cases := []struct {
+        name   string
+        mutate string
+    }{
+        {
+            name:   "missing path",
+            mutate: `DELETE FROM indexed_files WHERE path = '/sessions/source.jsonl';`,
+        },
+        {
+            name:   "real-looking but unverified hash",
+            mutate: `UPDATE indexed_files SET hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' WHERE path = '/sessions/source.jsonl';`,
+        },
+        {
+            name:   "non-null last indexed",
+            mutate: `UPDATE indexed_files SET last_indexed = '2026-08-19T00:00:00Z' WHERE path = '/sessions/source.jsonl';`,
+        },
+    }
+    // For every case, create a one-path recovery destination, mutate it,
+    // and require VerifyRecoveryDestination(ctx, destPath, plan) to fail.
+}
+```
+
+Keep the existing invented-extra-path tamper test; it covers the fourth exact-set failure mode.
+
+- [ ] **Step 3: Run the focused tests and confirm RED**
+
+Run:
+
+```bash
+go test ./internal/storage -run 'TestRecoveryDestination(Start|Verification|Independent)' -count=1
+```
+
+Expected: FAIL because recovery still produces zero accounting rows and the new marker identifiers do not exist.
+
+- [ ] **Step 4: Create the marker contract**
+
+Create `internal/storage/recovery_accounting.go`:
+
+```go
+package storage
+
+const recoveredSourceHash = "backscroll:recovered"
+
+func isRecoveredSourceHash(hash string) bool {
+    return hash == recoveredSourceHash
+}
+```
+
+Keep the marker unexported because it is an internal storage representation, not CLI or package API.
+
+- [ ] **Step 5: Insert deterministic provisional accounting**
+
+In `internal/storage/recovery_destination.go`, add these helpers:
+
+```go
+func recoveryDestinationSourcePaths(plan compat.RecoveryPlan) []string {
+    seen := make(map[string]struct{}, len(plan.Records))
+    for _, planned := range plan.Records {
+        seen[planned.Record.SourcePath] = struct{}{}
+    }
+    paths := make([]string, 0, len(seen))
+    for path := range seen {
+        paths = append(paths, path)
+    }
+    sort.Strings(paths)
+    return paths
+}
+
+func insertRecoveryDestinationAccounting(ctx context.Context, tx *sql.Tx, plan compat.RecoveryPlan) error {
+    for _, path := range recoveryDestinationSourcePaths(plan) {
+        if _, err := tx.ExecContext(ctx, `
+            INSERT INTO indexed_files (path, hash, last_indexed)
+            VALUES (?, ?, NULL)
+        `, path, recoveredSourceHash); err != nil {
+            return fmt.Errorf("insert recovered source accounting for %s: %w", path, err)
+        }
+    }
+    return nil
+}
+```
+
+Call `insertRecoveryDestinationAccounting(ctx, tx, plan)` immediately after the canonical record insertion loop and before `verifyRecoveryDestinationQueryer`. Wrap failure as `insert recovery source accounting: %w`.
+
+- [ ] **Step 6: Replace the zero-row verifier with exact marker verification**
+
+In `verifyRecoveryDestinationRows`, remove the `COUNT(*) == 0` block. Query all accounting rows ordered by path, scan `last_indexed` as `sql.NullString`, and compare against `recoveryDestinationSourcePaths(plan)`:
+
+```go
+rows, err := q.QueryContext(ctx, `
+    SELECT path, hash, last_indexed
+    FROM indexed_files
+    ORDER BY path
+`)
+if err != nil {
+    return fmt.Errorf("query recovered source accounting: %w", err)
+}
+
+var gotPaths []string
+for rows.Next() {
+    var path, hash string
+    var lastIndexed sql.NullString
+    if err := rows.Scan(&path, &hash, &lastIndexed); err != nil {
+        _ = rows.Close()
+        return fmt.Errorf("scan recovered source accounting: %w", err)
+    }
+    if !isRecoveredSourceHash(hash) {
+        _ = rows.Close()
+        return fmt.Errorf("recovered source accounting for %s has hash %q", path, hash)
+    }
+    if lastIndexed.Valid {
+        _ = rows.Close()
+        return fmt.Errorf("recovered source accounting for %s has last_indexed %q", path, lastIndexed.String)
+    }
+    gotPaths = append(gotPaths, path)
+}
+if err := rows.Err(); err != nil {
+    _ = rows.Close()
+    return fmt.Errorf("read recovered source accounting: %w", err)
+}
+if err := rows.Close(); err != nil {
+    return fmt.Errorf("close recovered source accounting: %w", err)
+}
+wantPaths := recoveryDestinationSourcePaths(plan)
+if !reflect.DeepEqual(gotPaths, wantPaths) {
+    return fmt.Errorf("recovered source accounting paths do not match plan")
+}
+```
+
+Do not add `reflect` solely for this comparison if a small existing slice-equality helper is clearer; if using `reflect.DeepEqual`, add the import explicitly. Ensure rows are closed before later queries on the single SQLite connection.
+
+- [ ] **Step 7: Run destination tests and confirm GREEN**
+
+Run:
+
+```bash
+go test ./internal/storage -run 'TestRecoveryDestination|TestPublishedGoLineagesUpgradeLosslessly' -count=1
+```
+
+Expected: PASS, including the existing canonical-row, FTS, cleanup, and tamper tests.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add internal/storage/recovery_accounting.go internal/storage/recovery_destination.go internal/storage/recovery_destination_test.go
+git commit -m "fix(storage): account for recovered source paths"
+```
+
+---
+
+### Task 2: Make sync, status, and backfill marker-aware
+
+**Files:**
+- Modify: `internal/storage/sync.go:320-342`
+- Modify: `internal/storage/queries.go:25-48`
+- Modify: `internal/storage/backfill.go:50-65`
+- Test: `internal/storage/storage_test.go:350-425`
+- Test: `internal/storage/backfill_test.go:1-50, 250-295`
+
+**Interfaces:**
+- Consumes: `isRecoveredSourceHash(string) bool` and `recoveredSourceHash` from Task 1.
+- Produces: `GetFileHashes()` containing only real source hashes, `GetStats()` containing only genuinely indexed file accounting, and `BackfillDerived()` eligibility for missing or provisionally recovered paths. `SyncFiles([]IndexedFile)` remains unchanged and replaces markers through its existing upsert.
+
+- [ ] **Step 1: Add failing hash-map and stats tests**
+
+Extend `TestGetFileHashes` after the normal sync:
+
+```go
+if _, err := db.db.Exec(`
+    INSERT INTO indexed_files (path, hash, last_indexed)
+    VALUES ('/path/to/recovered.jsonl', ?, NULL)
+`, recoveredSourceHash); err != nil {
+    t.Fatalf("insert recovered accounting: %v", err)
+}
+
+hashes, err := db.GetFileHashes()
+if err != nil {
+    t.Fatalf("failed to get hashes: %v", err)
+}
+if _, ok := hashes["/path/to/recovered.jsonl"]; ok {
+    t.Fatalf("GetFileHashes returned provisional recovered path")
+}
+```
+
+Add `TestGetStatsExcludesRecoveredSourceAccounting`:
+
+```go
+func TestGetStatsExcludesRecoveredSourceAccounting(t *testing.T) {
+    db, cleanup := newTestDB(t)
+    defer cleanup()
+
+    if _, err := db.db.Exec(`
+        INSERT INTO indexed_files (path, hash, last_indexed) VALUES
+        ('/real.jsonl', 'real-hash', '2026-08-18T12:00:00Z'),
+        ('/recovered.jsonl', ?, NULL)
+    `, recoveredSourceHash); err != nil {
+        t.Fatal(err)
+    }
+    stats, err := db.GetStats()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if stats.TotalFiles != 1 {
+        t.Fatalf("TotalFiles = %d, want 1", stats.TotalFiles)
+    }
+    want := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+    if !stats.IndexedAt.Equal(want) {
+        t.Fatalf("IndexedAt = %s, want %s", stats.IndexedAt, want)
+    }
+}
+```
+
+- [ ] **Step 2: Add a normal-sync replacement regression**
+
+Add `database/sql` to `storage_test.go` imports, then add `TestSyncFilesReplacesRecoveredSourceAccounting`:
+
+```go
+func TestSyncFilesReplacesRecoveredSourceAccounting(t *testing.T) {
+    db, cleanup := newTestDB(t)
+    defer cleanup()
+
+    const path = "/path/to/recovered.jsonl"
+    if _, err := db.db.Exec(`
+        INSERT INTO indexed_files (path, hash, last_indexed)
+        VALUES (?, ?, NULL)
+    `, path, recoveredSourceHash); err != nil {
+        t.Fatal(err)
+    }
+    err := db.SyncFiles([]IndexedFile{{
+        SourcePath: path,
+        Source:     "session",
+        Hash:       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        Project:    "proj",
+        Messages: []IndexedMessage{{
+            Ordinal: 0, Role: "user", Text: "resynced", UUID: getTestUUID(), ContentType: "text",
+        }},
+    }})
+    if err != nil {
+        t.Fatal(err)
+    }
+    var hash string
+    var lastIndexed sql.NullString
+    if err := db.db.QueryRow(`SELECT hash, last_indexed FROM indexed_files WHERE path = ?`, path).Scan(&hash, &lastIndexed); err != nil {
+        t.Fatal(err)
+    }
+    if hash == recoveredSourceHash || !lastIndexed.Valid {
+        t.Fatalf("accounting after sync = hash %q last_indexed %+v", hash, lastIndexed)
+    }
+}
+```
+
+This test should already pass once the marker exists, proving that no special `SyncFiles` branch is necessary.
+
+Also add `TestPurgeRemovesRecoveredSourceAccounting` to pin the final lifecycle transition:
+
+```go
+func TestPurgeRemovesRecoveredSourceAccounting(t *testing.T) {
+    db, cleanup := newTestDB(t)
+    defer cleanup()
+
+    const path = "/path/to/purged-recovery.jsonl"
+    if _, err := db.db.Exec(`
+        INSERT INTO search_items
+        (source, source_path, ordinal, role, text, timestamp, uuid, project, content_type)
+        VALUES ('session', ?, 0, 'user', 'old recovered row', '2026-01-01T00:00:00Z',
+                '33333333-3333-4333-8333-333333333333', 'proj', 'text')
+    `, path); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := db.db.Exec(`
+        INSERT INTO indexed_files (path, hash, last_indexed)
+        VALUES (?, ?, NULL)
+    `, path, recoveredSourceHash); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := db.Purge("2026-01-02T00:00:00Z"); err != nil {
+        t.Fatal(err)
+    }
+    var count int
+    if err := db.db.QueryRow(`SELECT COUNT(*) FROM indexed_files WHERE path = ?`, path).Scan(&count); err != nil {
+        t.Fatal(err)
+    }
+    if count != 0 {
+        t.Fatalf("recovered accounting survived purge")
+    }
+}
+```
+
+- [ ] **Step 3: Add a failing marked-path backfill test**
+
+Add `TestBackfillDerivedMinesRecoveredMarkedPath` beside `TestBackfillDerivedMinesTemplatesFromExpiredFile`:
+
+```go
+func TestBackfillDerivedMinesRecoveredMarkedPath(t *testing.T) {
+    db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer func() { _ = db.Close() }()
+
+    if _, err := db.db.Exec(`
+        INSERT INTO search_items
+        (source, source_path, ordinal, role, text, timestamp, uuid, project, content_type, extraction_version)
+        VALUES ('session', '/recovered/s.jsonl', 0, 'assistant', 'error: recovered failure 42',
+                '2026-01-01T00:00:00Z', 'recovered#t0', 'proj', 'tool', 1)
+    `); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := db.db.Exec(`
+        INSERT INTO indexed_files (path, hash, last_indexed)
+        VALUES ('/recovered/s.jsonl', ?, NULL)
+    `, recoveredSourceHash); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := db.BackfillDerived(BackfillDerivedOpts{}); err != nil {
+        t.Fatal(err)
+    }
+    var count int
+    if err := db.db.QueryRow(`SELECT COUNT(*) FROM message_templates`).Scan(&count); err != nil {
+        t.Fatal(err)
+    }
+    if count == 0 {
+        t.Fatal("marked recovered path was excluded from backfill")
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused tests and confirm RED where behavior is missing**
+
+Run:
+
+```bash
+go test ./internal/storage -run 'Test(GetFileHashes|GetStatsExcludesRecovered|SyncFilesReplacesRecovered|PurgeRemovesRecovered|BackfillDerivedMinesRecovered)' -count=1
+```
+
+Expected: hash-map, stats, and backfill tests FAIL; sync replacement PASS demonstrates the existing transition.
+
+- [ ] **Step 5: Filter provisional rows from the autosync skip map**
+
+Change `GetFileHashes` in `internal/storage/sync.go`:
+
+```go
+rows, err := d.db.Query(`
+    SELECT path, hash
+    FROM indexed_files
+    WHERE hash <> ?
+`, recoveredSourceHash)
+```
+
+Keep its return type and scan/error behavior unchanged.
+
+- [ ] **Step 6: Filter provisional rows from status statistics**
+
+Change both `GetStats` queries in `internal/storage/queries.go`:
+
+```go
+err := d.db.QueryRow(`
+    SELECT COUNT(*)
+    FROM indexed_files
+    WHERE hash <> ?
+`, recoveredSourceHash).Scan(&stats.TotalFiles)
+```
+
+```go
+err = d.db.QueryRow(`
+    SELECT MAX(last_indexed)
+    FROM indexed_files
+    WHERE hash <> ?
+`, recoveredSourceHash).Scan(&lastIndexed)
+```
+
+Do not alter message, chunk, embedding, or vector counts.
+
+- [ ] **Step 7: Include provisional paths in expired/recovery backfill discovery**
+
+Change the `BackfillDerived` discovery predicate and pass the marker as a parameter:
+
+```go
+rows, err := d.db.Query(`
+    SELECT DISTINCT si.source_path, si.source
+    FROM search_items si
+    LEFT JOIN indexed_files ifx ON si.source_path = ifx.path
+    WHERE
+        (ifx.path IS NULL OR ifx.hash = ?) AND
+        (NOT EXISTS (SELECT 1 FROM template_matches WHERE source_path = si.source_path) OR
+         NOT EXISTS (SELECT 1 FROM correction_signals WHERE source_path = si.source_path) OR
+         NOT EXISTS (SELECT 1 FROM tool_events WHERE source_path = si.source_path AND extraction_version = 0))
+    ORDER BY si.source_path
+`, recoveredSourceHash)
+```
+
+Keep the existing stale-template merge, batching, idempotency predicates, and transaction boundaries unchanged.
+
+- [ ] **Step 8: Run marker-consumer and broader storage tests**
+
+Run:
+
+```bash
+go test ./internal/storage -run 'Test(GetFileHashes|GetStats|SyncFiles|BackfillDerived|Purge|Validate)' -count=1
+```
+
+Expected: PASS. In particular, existing `TestBackfillDerivedSkipsOnDiskFiles` must still prove that a real hash excludes an on-disk path from lossy backfill.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add internal/storage/sync.go internal/storage/queries.go internal/storage/backfill.go internal/storage/storage_test.go internal/storage/backfill_test.go
+git commit -m "fix(storage): distinguish recovered source accounting"
+```
+
+---
+
+### Task 3: Add the CLI recovery-to-validation regression
+
+**Files:**
+- Modify: `cmd/backscroll/recover_test.go:1-15, 145-225, 370-425`
+- Read fixture: `tests/fixtures/recovery/active-v13.sql`
+- Read fixture: `tests/fixtures/recovery/stranded-v7.sql`
+
+**Interfaces:**
+- Consumes: the public `recover --from` and `validate --indexed-only` commands, supported v13/v7 fixture schemas, and recovery output's `backup path: ` field.
+- Produces: a hermetic regression proving the installed recovery destination is valid, complete, FTS-queryable, and backed up byte-for-byte.
+
+- [ ] **Step 1: Add a fixture database helper**
+
+Add `database/sql` to imports. Add this helper near `createRecoverTestDB`:
+
+```go
+func createRecoverFixtureDB(t *testing.T, path, fixture string, replacements map[string]string) {
+    t.Helper()
+    fixturePath := filepath.Join("..", "..", "tests", "fixtures", "recovery", fixture)
+    body, err := os.ReadFile(fixturePath)
+    if err != nil {
+        t.Fatalf("read recovery fixture %s: %v", fixturePath, err)
+    }
+    sqlText := string(body)
+    for from, to := range replacements {
+        sqlText = strings.ReplaceAll(sqlText, from, to)
+    }
+    db, err := sql.Open("sqlite", path)
+    if err != nil {
+        t.Fatalf("open recovery fixture %s: %v", path, err)
+    }
+    if _, err := db.Exec(sqlText); err != nil {
+        _ = db.Close()
+        t.Fatalf("execute recovery fixture %s: %v", fixture, err)
+    }
+    if err := db.Close(); err != nil {
+        t.Fatalf("close recovery fixture %s: %v", path, err)
+    }
+}
+```
+
+The `storage` package imported by this test already registers the modernc SQLite driver. Do not modify fixture files on disk.
+
+- [ ] **Step 2: Add the end-to-end regression**
+
+Add `TestRecoverInstalledDestinationPassesIndexedValidation`:
+
+```go
+func TestRecoverInstalledDestinationPassesIndexedValidation(t *testing.T) {
+    dir := t.TempDir()
+    home := filepath.Join(dir, "home")
+    if err := os.MkdirAll(home, 0o755); err != nil {
+        t.Fatal(err)
+    }
+    activePath := filepath.Join(dir, "active.db")
+    strandedPath := filepath.Join(dir, "stranded.db")
+    createRecoverFixtureDB(t, activePath, "active-v13.sql", map[string]string{
+        "uuid-active-v13": "11111111-1111-4111-8111-111111111111",
+    })
+    createRecoverFixtureDB(t, strandedPath, "stranded-v7.sql", map[string]string{
+        "uuid-stranded-v7": "22222222-2222-4222-8222-222222222222",
+    })
+    activeBefore, err := os.ReadFile(activePath)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    t.Setenv("HOME", home)
+    t.Setenv("BACKSCROLL_CONFIG_DIR", filepath.Join(dir, "config"))
+    t.Setenv("BACKSCROLL_DATABASE_PATH", activePath)
+    t.Chdir(dir)
+
+    var recoverOut, recoverErr bytes.Buffer
+    recoverCmd := buildRootCmd(&recoverOut, &recoverErr)
+    recoverCmd.SetArgs([]string{"recover", "--from", strandedPath})
+    if err := recoverCmd.Execute(); err != nil {
+        t.Fatalf("recover: %v\nstderr=%s", err, recoverErr.String())
+    }
+    if recoverErr.String() != "" {
+        t.Fatalf("recover stderr = %q, want empty", recoverErr.String())
+    }
+    backupPath := recoverOutputValue(t, recoverOut.String(), "backup path: ")
+    backupBytes, err := os.ReadFile(backupPath)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !bytes.Equal(backupBytes, activeBefore) {
+        t.Fatal("active backup differs from pre-recovery database")
+    }
+
+    var validateOut, validateErr bytes.Buffer
+    validateCmd := buildRootCmd(&validateOut, &validateErr)
+    validateCmd.SetArgs([]string{"validate", "--indexed-only"})
+    if err := validateCmd.Execute(); err != nil {
+        t.Fatalf("validate recovered destination: %v\nstdout=%s\nstderr=%s", err, validateOut.String(), validateErr.String())
+    }
+    if validateErr.String() != "" {
+        t.Fatalf("validate stderr = %q, want empty", validateErr.String())
+    }
+
+    db, err := storage.OpenReadOnly(activePath)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer func() { _ = db.Close() }()
+    var records, accountedPaths, ftsHits int
+    if err := db.DB().QueryRow(`SELECT COUNT(*) FROM search_items`).Scan(&records); err != nil {
+        t.Fatal(err)
+    }
+    if err := db.DB().QueryRow(`SELECT COUNT(*) FROM indexed_files`).Scan(&accountedPaths); err != nil {
+        t.Fatal(err)
+    }
+    if err := db.DB().QueryRow(`SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'default'`).Scan(&ftsHits); err != nil {
+        t.Fatal(err)
+    }
+    if records != 4 || accountedPaths != 4 || ftsHits != 2 {
+        t.Fatalf("recovered database counts records=%d paths=%d fts=%d, want 4/4/2", records, accountedPaths, ftsHits)
+    }
+}
+```
+
+The expected accounting count is four because the two fixtures contain four distinct `source_path` values. Retain command output in failure messages so a regression is diagnosable.
+
+- [ ] **Step 3: Run the end-to-end regression**
+
+Run:
+
+```bash
+go test ./cmd/backscroll -run TestRecoverInstalledDestinationPassesIndexedValidation -count=1
+```
+
+Expected: PASS. The RED behavior is already pinned by Task 1's failing destination-accounting tests: on the original implementation, recovery produced zero accounting rows and public validation reported four orphaned `search_items`.
+
+- [ ] **Step 4: Run all recovery and compatibility command tests**
+
+Run:
+
+```bash
+go test ./cmd/backscroll -run 'TestRecover|TestValidateCurrentIndexIntegrityFailureIsGenericAndReadOnly' -count=1
+```
+
+Expected: PASS. The existing genuine-orphan test must continue reporting `orphaned search_items`; recovery diagnostics and backup behavior must remain unchanged.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add cmd/backscroll/recover_test.go
+git commit -m "test(recovery): validate installed recovered index"
+```
+
+---
+
+### Task 4: Run the complete quality gate and review the diff
+
+**Files:**
+- Verify only; modify earlier files only if a failing gate reveals a defect.
+
+**Interfaces:**
+- Consumes: all Task 1-3 commits.
+- Produces: a verified implementation satisfying issue #35 and the repository's aggregate coverage gate.
+
+- [ ] **Step 1: Check formatting and static analysis**
+
+Run:
+
+```bash
+just check
+```
+
+Expected: PASS (`gofmt --check` and `go vet`). If formatting fails, run `just fmt`, inspect the diff, and recommit only the formatting changes with the task that introduced them.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+
+```bash
+just test
+```
+
+Expected: PASS for every package.
+
+- [ ] **Step 3: Run the release-blocking CI mirror**
+
+Run:
+
+```bash
+just ci
+```
+
+Expected: build succeeds, scrubbed-HOME tests pass, race checks pass, and aggregate statement coverage is at least 85%.
+
+- [ ] **Step 4: Review the final diff against the spec**
+
+Run:
+
+```bash
+git diff HEAD~3..HEAD --check
+git diff HEAD~3..HEAD --stat
+git log --oneline -4
+```
+
+Confirm all of the following from tests and code:
+
+- recovery writes exact marked accounting with NULL `last_indexed`;
+- validation still uses path presence and rejects genuine orphans;
+- hashes and status exclude markers;
+- backfill includes markers;
+- normal sync replaces markers;
+- purge uses its existing last-row cleanup;
+- no migration, schema edit, JSONL write, or unrelated refactor was added.
+
+- [ ] **Step 5: Record any gate-only fix**
+
+If Step 1-4 required a code change, rerun the narrow failing test and all three quality commands, then commit with a precise conventional message such as:
+
+```bash
+git add internal/storage/recovery_accounting.go internal/storage/recovery_destination.go internal/storage/recovery_destination_test.go internal/storage/sync.go internal/storage/queries.go internal/storage/backfill.go internal/storage/storage_test.go internal/storage/backfill_test.go cmd/backscroll/recover_test.go
+git commit -m "fix(storage): preserve recovered accounting invariant"
+```
+
+If no change was required, do not create an empty commit.

--- a/docs/superpowers/specs/2026-08-19-recovered-source-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-19-recovered-source-accounting-design.md
@@ -1,0 +1,180 @@
+# Recovered Source Accounting Design
+
+**Date:** 2026-08-19  
+**Issue:** [#35 — recovered index immediately fails validate as orphaned](https://github.com/pablontiv/backscroll/issues/35)
+
+## Summary
+
+`backscroll recover` currently installs the canonical union of records from the active and stranded databases while leaving `indexed_files` empty. The resulting database passes recovery's private verifier but immediately fails the public `validate --indexed-only` orphan check.
+
+Recovery will add explicit provisional source accounting to `indexed_files`. Each distinct `search_items.source_path` in the recovery plan will receive the reserved marker `backscroll:recovered` instead of a content hash. Consumers will distinguish this marker from a real SHA-256: validation will accept the accounted path, derived-data backfill will continue treating it as recoverable stored data, and autosync will not treat it as an unchanged source. A later real sync will replace the marker with the source file's actual hash.
+
+This change reconstructs database accounting only. It never creates, restores, or modifies session JSONL files.
+
+## Goals
+
+- Make a successfully recovered destination pass `validate --indexed-only` immediately.
+- Preserve detection of genuine orphaned `search_items` rows.
+- Represent unknown post-recovery source state explicitly without inventing a SHA-256.
+- Keep recovered rows eligible for `BackfillDerived()` when their original sources are absent.
+- Force a source that does exist on disk to be parsed on the next sync.
+- Preserve canonical rows, FTS queryability, atomic installation, and the byte-identical active backup guarantee.
+
+## Non-goals
+
+- Recovering, recreating, or modifying original JSONL or Markdown source files.
+- Preserving permanent historical provenance after a source has been synced normally.
+- Introducing a new schema table or migration.
+- Relaxing public validation for unaccounted rows.
+- Recovering lossy derived metadata that is absent from canonical recovery records.
+
+## Existing Invariant Conflict
+
+Three existing behaviors conflict:
+
+1. `verifyRecoveryDestinationRows` requires zero `indexed_files` rows in a recovery destination.
+2. `Database.Validate` requires every `search_items.source_path` to exist in `indexed_files`.
+3. `BackfillDerived` uses absence from `indexed_files` to identify stored rows whose source is no longer available through normal sync.
+
+The fix must account for recovered paths for validation without making them look synchronized or excluding them from backfill.
+
+## Design
+
+### Reserved accounting marker
+
+Storage will define one internal reserved value:
+
+```text
+backscroll:recovered
+```
+
+The value is deliberately outside the lowercase 64-character hexadecimal format produced by SHA-256. It means:
+
+> Records for this source path were reconstructed from a database recovery plan; no current content hash for the original source is known.
+
+The marker is provisional. When `SyncFiles` later processes the corresponding source, its existing `INSERT OR REPLACE` into `indexed_files` replaces the marker with the real hash.
+
+### Recovery destination creation
+
+`CreateRecoveryDestination` will continue inserting every canonical recovery record into `search_items` inside the existing transaction. Before destination verification and commit, it will also:
+
+1. Collect each distinct `SourcePath` from the applicable recovery plan.
+2. Insert exactly one `indexed_files` row per distinct path.
+3. Store `backscroll:recovered` as the row's `hash`.
+4. Store `NULL` for `last_indexed`, because recovery did not index the original source at that time.
+
+The table's primary key on `path` provides uniqueness. No source file is read or written during this operation.
+
+### Recovery destination verification
+
+`verifyRecoveryDestinationRows` will replace its current `indexed_files count = 0` rule with exact provisional-accounting verification:
+
+- the destination has one accounting row per distinct planned `SourcePath`;
+- every expected path exists;
+- every expected row contains `backscroll:recovered`;
+- no additional `indexed_files` rows exist.
+
+Any missing path, unexpected path, duplicate-equivalent accounting mismatch, or incorrect marker fails destination verification before installation. Existing canonical-record and FTS verification remains unchanged.
+
+### Public validation
+
+`Database.Validate` retains its current orphan invariant: every `search_items.source_path` must have a corresponding `indexed_files.path`.
+
+Recovered destinations now satisfy that invariant through explicit provisional accounting. A row inserted without either normal or recovery accounting remains a genuine orphan and continues to fail validation.
+
+### Incremental sync
+
+`GetFileHashes` supplies the skip map used by autosync. It will omit rows whose hash is `backscroll:recovered`.
+
+Consequences:
+
+- If an original source still exists, discovery and hashing proceed normally; because the path is absent from the returned skip map, the reader parses it and `SyncFiles` replaces the marker with its real SHA-256.
+- If an original source no longer exists, discovery never returns it; the recovered database rows remain perennial and untouched.
+
+No special branch is required in `SyncFiles`: its existing `INSERT OR REPLACE` behavior performs the state transition atomically with the normal sync transaction.
+
+### Status accounting
+
+`GetStats` will exclude `backscroll:recovered` rows from `TotalFiles` and from the `IndexedAt` maximum. Those fields describe sources actually indexed from disk, whereas recovered database records are reported by the existing message counts. This prevents recovery time or provisional paths from masquerading as a successful source sync.
+
+### Derived-data backfill
+
+`BackfillDerived` will classify a source path as recovery/expired input when either:
+
+- no matching `indexed_files` row exists, or
+- the matching row's hash is `backscroll:recovered`.
+
+All existing missing-derivation predicates remain in effect. This preserves idempotency and prevents repeated work after templates, correction signals, and lossy tool events have been derived.
+
+### Purge lifecycle
+
+`Purge` already removes an `indexed_files` entry when no `search_items` remain for its path. The same behavior applies to provisional recovery markers, so no marker remains after the last recovered row for a path is purged.
+
+## Data Flow
+
+```text
+active DB + stranded DB
+          |
+          v
+ canonical recovery plan
+          |
+          +--> search_items: canonical recovered rows
+          |
+          +--> indexed_files: one path -> backscroll:recovered marker
+          |
+          v
+ destination verification -> atomic installation -> validate succeeds
+
+Later autosync:
+  source absent  -> recovered rows and marker remain; backfill may derive data
+  source present -> GetFileHashes omits marker -> parse -> SyncFiles writes real SHA-256
+```
+
+## Error Handling
+
+- Marker insertion failures abort and roll back destination creation.
+- Accounting verification failures reject the destination before installation.
+- The independent post-commit immutable verification applies the same accounting rules.
+- Errors continue using the existing recovery destination error wrappers and cleanup behavior.
+- Autosync and backfill database errors keep their existing contextual wrapping.
+- No fallback invents or accepts a normal-looking content hash.
+
+## Testing
+
+### CLI regression
+
+Add a full command-level regression using supported active and stranded databases:
+
+1. Capture the active database bytes.
+2. Run `recover --from <stranded>`.
+3. Run `validate --indexed-only` against the installed destination and require success.
+4. Confirm the reported backup is byte-identical to the original active database.
+5. Confirm all expected recovered records remain queryable.
+
+### Storage tests
+
+Cover these invariants directly:
+
+- Recovery creates one marked accounting row per distinct planned source path.
+- Destination verification rejects a missing accounting row.
+- Destination verification rejects an incorrect marker.
+- Destination verification rejects an unexpected accounting path.
+- Messages and tool records remain queryable through their respective FTS indexes.
+- `GetFileHashes` returns real hashes but omits provisional recovery markers.
+- `GetStats` excludes provisional markers from file count and last-indexed time.
+- `BackfillDerived` processes a marked recovered path.
+- `SyncFiles` replaces a marker with the real source hash.
+- `Purge` removes a marker after deleting the final row for its path.
+- The existing genuine-orphan validation regression continues to fail as expected.
+
+### Verification commands
+
+```bash
+just check
+just test
+just ci
+```
+
+## Documentation Impact
+
+This change adds no CLI option and no migration. Internal comments should document the marker contract where it is defined and where queries intentionally include or exclude it. The repository architecture documentation does not need a new package entry because no package is added or removed.

--- a/docs/superpowers/specs/2026-08-19-recovered-source-accounting-design.md
+++ b/docs/superpowers/specs/2026-08-19-recovered-source-accounting-design.md
@@ -1,6 +1,6 @@
 # Recovered Source Accounting Design
 
-**Date:** 2026-08-19  
+**Date:** 2026-08-19
 **Issue:** [#35 — recovered index immediately fails validate as orphaned](https://github.com/pablontiv/backscroll/issues/35)
 
 ## Summary

--- a/internal/storage/backfill.go
+++ b/internal/storage/backfill.go
@@ -46,8 +46,9 @@ func (d *Database) BackfillDerived(opts BackfillDerivedOpts) error {
 		pathsToProcess[p] = "session"
 	}
 
-	// Find files in search_items that are EXPIRED: absent from indexed_files.
-	// Within expired files, process only those missing at least one of the three derivations:
+	// Find files in search_items that are EXPIRED (absent from indexed_files)
+	// or provisionally recovered. Within those files, process only those missing
+	// at least one of the three derivations:
 	// - template_matches (templates mined), OR
 	// - correction_signals (corrections detected), OR
 	// - tool_events with extraction_version = 0 (lossy tool metadata extracted)
@@ -56,12 +57,12 @@ func (d *Database) BackfillDerived(opts BackfillDerivedOpts) error {
 		FROM search_items si
 		LEFT JOIN indexed_files ifx ON si.source_path = ifx.path
 		WHERE
-			ifx.path IS NULL AND
+			(ifx.path IS NULL OR ifx.hash = ?) AND
 			(NOT EXISTS (SELECT 1 FROM template_matches WHERE source_path = si.source_path) OR
 			 NOT EXISTS (SELECT 1 FROM correction_signals WHERE source_path = si.source_path) OR
 			 NOT EXISTS (SELECT 1 FROM tool_events WHERE source_path = si.source_path AND extraction_version = 0))
 		ORDER BY si.source_path
-	`)
+	`, recoveredSourceHash)
 	if err != nil {
 		return fmt.Errorf("query expired files: %w", err)
 	}

--- a/internal/storage/backfill_test.go
+++ b/internal/storage/backfill_test.go
@@ -49,6 +49,40 @@ func TestBackfillDerivedMinesTemplatesFromExpiredFile(t *testing.T) {
 	}
 }
 
+func TestBackfillDerivedMinesRecoveredMarkedPath(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.db.Exec(`
+		INSERT INTO search_items
+		(source, source_path, ordinal, role, text, timestamp, uuid, project, content_type, extraction_version)
+		VALUES ('session', '/recovered/s.jsonl', 0, 'assistant', 'error: recovered failure 42',
+				'2026-01-01T00:00:00Z', 'recovered#t0', 'proj', 'tool', 1)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.db.Exec(`
+		INSERT INTO indexed_files (path, hash, last_indexed)
+		VALUES ('/recovered/s.jsonl', ?, NULL)
+	`, recoveredSourceHash); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.BackfillDerived(BackfillDerivedOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM message_templates`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
+		t.Fatal("marked recovered path was excluded from backfill")
+	}
+}
+
 func TestBackfillDerivedIsIdempotent(t *testing.T) {
 	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -28,7 +28,11 @@ func (d *Database) GetStats() (Stats, error) {
 	var stats Stats
 
 	// Get total files
-	err := d.db.QueryRow("SELECT COUNT(*) FROM indexed_files").Scan(&stats.TotalFiles)
+	err := d.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM indexed_files
+		WHERE hash <> ?
+	`, recoveredSourceHash).Scan(&stats.TotalFiles)
 	if err != nil {
 		return stats, fmt.Errorf("count files: %w", err)
 	}
@@ -41,7 +45,11 @@ func (d *Database) GetStats() (Stats, error) {
 
 	// Get last indexed time (most recent timestamp)
 	var lastIndexed sql.NullString
-	err = d.db.QueryRow("SELECT MAX(last_indexed) FROM indexed_files").Scan(&lastIndexed)
+	err = d.db.QueryRow(`
+		SELECT MAX(last_indexed)
+		FROM indexed_files
+		WHERE hash <> ?
+	`, recoveredSourceHash).Scan(&lastIndexed)
 	if err != nil && err != sql.ErrNoRows {
 		return stats, fmt.Errorf("get last indexed: %w", err)
 	}

--- a/internal/storage/recovery_accounting.go
+++ b/internal/storage/recovery_accounting.go
@@ -1,0 +1,7 @@
+package storage
+
+const recoveredSourceHash = "backscroll:recovered"
+
+func isRecoveredSourceHash(hash string) bool {
+	return hash == recoveredSourceHash
+}

--- a/internal/storage/recovery_destination.go
+++ b/internal/storage/recovery_destination.go
@@ -129,6 +129,9 @@ func CreateRecoveryDestination(ctx context.Context, dir string, plan compat.Reco
 			return "", fmt.Errorf("insert recovery record %d: %w", i, err)
 		}
 	}
+	if err := insertRecoveryDestinationAccounting(ctx, tx, plan); err != nil {
+		return "", fmt.Errorf("insert recovery source accounting: %w", err)
+	}
 	if err := verifyRecoveryDestinationQueryer(ctx, tx, plan); err != nil {
 		return "", fmt.Errorf("verify recovery destination before commit: %w", err)
 	}
@@ -211,6 +214,31 @@ func insertRecoveryDestinationRecord(ctx context.Context, tx *sql.Tx, r models.I
 	return nil
 }
 
+func recoveryDestinationSourcePaths(plan compat.RecoveryPlan) []string {
+	seen := make(map[string]struct{}, len(plan.Records))
+	for _, planned := range plan.Records {
+		seen[planned.Record.SourcePath] = struct{}{}
+	}
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func insertRecoveryDestinationAccounting(ctx context.Context, tx *sql.Tx, plan compat.RecoveryPlan) error {
+	for _, path := range recoveryDestinationSourcePaths(plan) {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO indexed_files (path, hash, last_indexed)
+			VALUES (?, ?, NULL)
+		`, path, recoveredSourceHash); err != nil {
+			return fmt.Errorf("insert recovered source accounting for %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
 func verifyRecoveryDestinationQueryer(ctx context.Context, q compat.Queryer, plan compat.RecoveryPlan) error {
 	if err := compat.VerifyCurrentShape(ctx, q); err != nil {
 		return fmt.Errorf("current schema signature: %w", err)
@@ -235,12 +263,43 @@ func verifyRecoveryDestinationRows(ctx context.Context, q compat.Queryer, plan c
 	if rowCount != len(plan.Records) {
 		return fmt.Errorf("search_items count = %d, want %d", rowCount, len(plan.Records))
 	}
-	var indexedFileCount int
-	if err := q.QueryRowContext(ctx, `SELECT COUNT(*) FROM indexed_files`).Scan(&indexedFileCount); err != nil {
-		return fmt.Errorf("count indexed_files: %w", err)
+	rows, err := q.QueryContext(ctx, `
+		SELECT path, hash, last_indexed
+		FROM indexed_files
+		ORDER BY path
+	`)
+	if err != nil {
+		return fmt.Errorf("query recovered source accounting: %w", err)
 	}
-	if indexedFileCount != 0 {
-		return fmt.Errorf("indexed_files count = %d, want 0 for recovery destination source accounting", indexedFileCount)
+
+	var gotPaths []string
+	for rows.Next() {
+		var path, hash string
+		var lastIndexed sql.NullString
+		if err := rows.Scan(&path, &hash, &lastIndexed); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan recovered source accounting: %w", err)
+		}
+		if !isRecoveredSourceHash(hash) {
+			_ = rows.Close()
+			return fmt.Errorf("recovered source accounting for %s has hash %q", path, hash)
+		}
+		if lastIndexed.Valid {
+			_ = rows.Close()
+			return fmt.Errorf("recovered source accounting for %s has last_indexed %q", path, lastIndexed.String)
+		}
+		gotPaths = append(gotPaths, path)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("read recovered source accounting: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close recovered source accounting: %w", err)
+	}
+	wantPaths := recoveryDestinationSourcePaths(plan)
+	if !recoveryDestinationStringSlicesEqual(gotPaths, wantPaths) {
+		return fmt.Errorf("recovered source accounting paths do not match plan")
 	}
 
 	records, diag, err := readCanonicalSearchItems(ctx, q)
@@ -480,6 +539,18 @@ func recoveryDestinationFTSToken(text string) string {
 	}
 	sort.SliceStable(tokens, func(i, j int) bool { return len(tokens[i]) > len(tokens[j]) })
 	return strings.ToLower(tokens[0])
+}
+
+func recoveryDestinationStringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i, leftValue := range left {
+		if right[i] != leftValue {
+			return false
+		}
+	}
+	return true
 }
 
 func recoveryDestinationStringBoolMapsEqual(left, right map[string]bool) bool {

--- a/internal/storage/recovery_destination_test.go
+++ b/internal/storage/recovery_destination_test.go
@@ -316,13 +316,7 @@ func TestRecoveryDestinationStartsFreshAtCurrentSchema(t *testing.T) {
 	if recoveryDestinationColumnExists(t, db, "search_items", "source_metadata") {
 		t.Fatal("destination has legacy source_metadata column; want fresh current schema")
 	}
-	var indexedFiles int
-	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM indexed_files`).Scan(&indexedFiles); err != nil {
-		t.Fatalf("count indexed_files: %v", err)
-	}
-	if indexedFiles != 0 {
-		t.Fatalf("indexed_files rows = %d, want 0 in fresh recovery destination", indexedFiles)
-	}
+	assertRecoveryDestinationAccounting(t, db.DB(), plan)
 }
 
 func TestRecoveryDestinationIndependentVerificationRejectsTamper(t *testing.T) {
@@ -348,6 +342,49 @@ func TestRecoveryDestinationIndependentVerificationRejectsTamper(t *testing.T) {
 	`)
 	if err := VerifyRecoveryDestination(ctx, destPath, plan); err == nil {
 		t.Fatal("VerifyRecoveryDestination accepted a tampered destination with invented source accounting")
+	}
+}
+
+func TestRecoveryDestinationVerificationRejectsInvalidRecoveredAccounting(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate string
+	}{
+		{
+			name:   "missing path",
+			mutate: `DELETE FROM indexed_files WHERE path = '/sessions/source.jsonl';`,
+		},
+		{
+			name:   "real-looking but unverified hash",
+			mutate: `UPDATE indexed_files SET hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' WHERE path = '/sessions/source.jsonl';`,
+		},
+		{
+			name:   "non-null last indexed",
+			mutate: `UPDATE indexed_files SET last_indexed = '2026-08-19T00:00:00Z' WHERE path = '/sessions/source.jsonl';`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			sourcePath := filepath.Join(dir, "source.db")
+			createRecoveryDestinationSourceDB(t, sourcePath, []IndexedFile{
+				recoveryDestinationIndexedFile("/sessions/source.jsonl", "source-hash", []IndexedMessage{{
+					Ordinal: 0, Role: "assistant", Text: "accounting tamper sentinel", UUID: "11111111-1111-4111-8111-111111111111",
+					Timestamp: "2026-08-18T00:00:00Z", ContentType: "text", ExtractionVersion: CurrentExtractionVersion,
+				}}),
+			})
+			plan := recoveryDestinationPlanFromDBs(t, ctx, sourcePath)
+			destPath, err := CreateRecoveryDestination(ctx, dir, plan)
+			if err != nil {
+				t.Fatalf("CreateRecoveryDestination: %v", err)
+			}
+
+			mutateRecoveryDatabase(t, destPath, tc.mutate)
+			if err := VerifyRecoveryDestination(ctx, destPath, plan); err == nil {
+				t.Fatalf("VerifyRecoveryDestination accepted %s recovered source accounting tampering", tc.name)
+			}
+		})
 	}
 }
 
@@ -662,12 +699,48 @@ func assertRecoveryDestinationRecords(t *testing.T, path string, plan compat.Rec
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("destination records mismatch\ngot:  %#v\nwant: %#v", got, want)
 	}
-	var indexedFiles int
-	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM indexed_files`).Scan(&indexedFiles); err != nil {
-		t.Fatalf("count indexed_files: %v", err)
+	assertRecoveryDestinationAccounting(t, db.DB(), plan)
+}
+
+func assertRecoveryDestinationAccounting(t *testing.T, db *sql.DB, plan compat.RecoveryPlan) {
+	t.Helper()
+	rows, err := db.Query(`
+		SELECT path, hash, last_indexed
+		FROM indexed_files
+		ORDER BY path
+	`)
+	if err != nil {
+		t.Fatalf("query recovered source accounting: %v", err)
 	}
-	if indexedFiles != 0 {
-		t.Fatalf("indexed_files rows = %d, want 0; recovery must not invent source hashes", indexedFiles)
+	defer func() { _ = rows.Close() }()
+
+	var gotPaths []string
+	for rows.Next() {
+		var path, hash string
+		var lastIndexed sql.NullString
+		if err := rows.Scan(&path, &hash, &lastIndexed); err != nil {
+			t.Fatalf("scan recovered source accounting: %v", err)
+		}
+		if hash != recoveredSourceHash || lastIndexed.Valid {
+			t.Fatalf("accounting for %s = hash %q last_indexed %+v", path, hash, lastIndexed)
+		}
+		gotPaths = append(gotPaths, path)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read recovered source accounting: %v", err)
+	}
+
+	seen := make(map[string]struct{}, len(plan.Records))
+	for _, planned := range plan.Records {
+		seen[planned.Record.SourcePath] = struct{}{}
+	}
+	wantPaths := make([]string, 0, len(seen))
+	for path := range seen {
+		wantPaths = append(wantPaths, path)
+	}
+	sort.Strings(wantPaths)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("recovered source accounting paths = %#v, want %#v", gotPaths, wantPaths)
 	}
 }
 

--- a/internal/storage/recovery_destination_test.go
+++ b/internal/storage/recovery_destination_test.go
@@ -730,16 +730,8 @@ func assertRecoveryDestinationAccounting(t *testing.T, db *sql.DB, plan compat.R
 		t.Fatalf("read recovered source accounting: %v", err)
 	}
 
-	seen := make(map[string]struct{}, len(plan.Records))
-	for _, planned := range plan.Records {
-		seen[planned.Record.SourcePath] = struct{}{}
-	}
-	wantPaths := make([]string, 0, len(seen))
-	for path := range seen {
-		wantPaths = append(wantPaths, path)
-	}
-	sort.Strings(wantPaths)
-	if !reflect.DeepEqual(gotPaths, wantPaths) {
+	wantPaths := recoveryDestinationSourcePaths(plan)
+	if !recoveryDestinationStringSlicesEqual(gotPaths, wantPaths) {
 		t.Fatalf("recovered source accounting paths = %#v, want %#v", gotPaths, wantPaths)
 	}
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -417,6 +418,85 @@ func TestGetFileHashes(t *testing.T) {
 	if hashes["/path/to/session1.jsonl"] != "hash123" {
 		t.Fatalf("hash mismatch")
 	}
+
+	if _, err := db.db.Exec(`
+		INSERT INTO indexed_files (path, hash, last_indexed)
+		VALUES ('/path/to/recovered.jsonl', ?, NULL)
+	`, recoveredSourceHash); err != nil {
+		t.Fatalf("insert recovered accounting: %v", err)
+	}
+
+	hashes, err = db.GetFileHashes()
+	if err != nil {
+		t.Fatalf("failed to get hashes: %v", err)
+	}
+	if _, ok := hashes["/path/to/recovered.jsonl"]; ok {
+		t.Fatalf("GetFileHashes returned provisional recovered path")
+	}
+}
+
+func TestSyncFilesReplacesRecoveredSourceAccounting(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	const path = "/path/to/recovered.jsonl"
+	if _, err := db.db.Exec(`
+		INSERT INTO indexed_files (path, hash, last_indexed)
+		VALUES (?, ?, NULL)
+	`, path, recoveredSourceHash); err != nil {
+		t.Fatal(err)
+	}
+	err := db.SyncFiles([]IndexedFile{{
+		SourcePath: path,
+		Source:     "session",
+		Hash:       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Project:    "proj",
+		Messages: []IndexedMessage{{
+			Ordinal: 0, Role: "user", Text: "resynced", UUID: getTestUUID(), ContentType: "text",
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hash string
+	var lastIndexed sql.NullString
+	if err := db.db.QueryRow(`SELECT hash, last_indexed FROM indexed_files WHERE path = ?`, path).Scan(&hash, &lastIndexed); err != nil {
+		t.Fatal(err)
+	}
+	if hash == recoveredSourceHash || !lastIndexed.Valid {
+		t.Fatalf("accounting after sync = hash %q last_indexed %+v", hash, lastIndexed)
+	}
+}
+
+func TestPurgeRemovesRecoveredSourceAccounting(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	const path = "/path/to/purged-recovery.jsonl"
+	if _, err := db.db.Exec(`
+		INSERT INTO search_items
+		(source, source_path, ordinal, role, text, timestamp, uuid, project, content_type)
+		VALUES ('session', ?, 0, 'user', 'old recovered row', '2026-01-01T00:00:00Z',
+				'33333333-3333-4333-8333-333333333333', 'proj', 'text')
+	`, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.db.Exec(`
+		INSERT INTO indexed_files (path, hash, last_indexed)
+		VALUES (?, ?, NULL)
+	`, path, recoveredSourceHash); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Purge("2026-01-02T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM indexed_files WHERE path = ?`, path).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("recovered accounting survived purge")
+	}
 }
 
 // TestSearch performs a basic search query.
@@ -638,6 +718,30 @@ func TestGetStats(t *testing.T) {
 
 	if stats.TotalMessages != 2 {
 		t.Fatalf("expected 2 messages, got %d", stats.TotalMessages)
+	}
+}
+
+func TestGetStatsExcludesRecoveredSourceAccounting(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	if _, err := db.db.Exec(`
+		INSERT INTO indexed_files (path, hash, last_indexed) VALUES
+		('/real.jsonl', 'real-hash', '2026-08-18T12:00:00Z'),
+		('/recovered.jsonl', ?, NULL)
+	`, recoveredSourceHash); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := db.GetStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.TotalFiles != 1 {
+		t.Fatalf("TotalFiles = %d, want 1", stats.TotalFiles)
+	}
+	want := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	if !stats.IndexedAt.Equal(want) {
+		t.Fatalf("IndexedAt = %s, want %s", stats.IndexedAt, want)
 	}
 }
 

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -318,7 +318,11 @@ func (d *Database) refreshStopwords() error {
 
 // GetFileHashes returns a map of file paths to their stored hashes.
 func (d *Database) GetFileHashes() (map[string]string, error) {
-	rows, err := d.db.Query("SELECT path, hash FROM indexed_files")
+	rows, err := d.db.Query(`
+		SELECT path, hash
+		FROM indexed_files
+		WHERE hash <> ?
+	`, recoveredSourceHash)
 	if err != nil {
 		return nil, fmt.Errorf("query file hashes: %w", err)
 	}


### PR DESCRIPTION
## What

- add explicit provisional source accounting for recovered database rows
- preserve backfill eligibility and force real sources to re-sync
- add a v13 + v7 CLI regression proving `recover` → `validate --indexed-only`

## Why

A successful recovery installed canonical `search_items` while leaving `indexed_files` empty, so the resulting database immediately failed public validation as orphaned.

Fixes #35.

## How

Recovery writes one `indexed_files` row per distinct recovered `source_path` using the reserved `backscroll:recovered` marker and `NULL last_indexed`. Destination verification requires the exact marker set. Hash/status queries exclude provisional rows, `BackfillDerived` includes them, and the existing `SyncFiles`/`Purge` lifecycle replaces or removes them without a schema migration.

## Checklist

- [x] Tests pass (`just test`, `just ci`)
- [x] Code is clean (`just check`, `git diff --check`)
- [x] Snapshots updated if needed (not applicable)
- [x] Changes are documented
