### PR TITLE
fix(config): require declarative markdown sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Backscroll is a Go CLI tool that indexes Claude Code, Pi, and OpenCode sessions, plans, and external knowledge sources into SQLite for full-text search (BM25 via FTS5). It treats sessions as an event store with incremental sync via SHA-256 deduplication.
+Backscroll is a Go CLI tool that indexes Claude Code, Pi, OpenCode, and declarative Markdown inputs (`markdown_document`, `markdown_sections`) plus plans into SQLite for full-text search (BM25 via FTS5). It treats sessions as an event store with incremental sync via SHA-256 deduplication.
 
 **Status**: Go port complete — `main` branch is the active Go implementation. The Rust implementation is frozen in the `v0` branch.
 
@@ -64,7 +64,7 @@ internal/
 ├── sources/           — external source parsers (ke, decision, memory, rule, spec, backlog) + SourceRegistry
 ├── projects/          — project identity registry: LoadGlobalRegistry(), Identify(), LoadLocalHint()
 ├── reader/            — direct reading and filtering of individual session files
-├── readers/           — SessionReader interface, Registry, ClaudeReader (text+tool_use+tool_result), PiReader (text+toolCall+custom results), OpenCodeReader (text+tool state.input+state.output); toolfmt serializer
+├── readers/           — SessionReader interface, Registry, ClaudeReader (text+tool_use+tool_result), PiReader (text+toolCall+custom results), OpenCodeReader (text+tool state.input+state.output), MarkdownDocumentReader (`markdown_document`), MarkdownSectionsReader (`markdown_sections`); toolfmt serializer
 ├── recovery/          — stranded database recovery orchestration, verified active+stranded union, durable backup, and atomic replacement
 ├── templates/         — F2 Drain-inspired miner: Miner, ProcessLine, ExtractErrorLines, deterministic signature via SHA256
 ├── corrections/       — F3 correction detection: bilingual lexicon, interrupt flags, denial heuristics, rephrase-similarity; detector registry + implementations
@@ -82,16 +82,16 @@ The `SearchEngine` interface is the port; `internal/storage` is the adapter. Dat
 ```
 JSONL files → fs.WalkDir → SHA-256 dedup → ParseSessions() ─┐
 Markdown plans → DiscoverPlanFiles() → ParsePlan() ──────────┤
-External sources → SourceRegistry.ParseAll() ─────────────────┤
+Declarative Markdown inputs → markdown readers ──────────────┤
                                                               ▼
                                               SyncFiles() → SQLite FTS5
                                                             │
 CLI query → Search() → BM25 → format_results()
 ```
 
-### External Source Types
+### Declarative Markdown Source Types
 
-Configurable in `[sources]` section of `backscroll.toml`. Source types: `ke`, `decision`, `memory`, `rule`, `spec`, `backlog`. Each has per-type parsers (whole-document or sectioned by ## headers). All filterable via `--source` flag.
+External knowledge sources are configured with active `*.inputs.toml` manifests under `<config_dir>/backscroll/inputs/`, not with legacy `[sources]` tables. Supported Markdown decode formats are `markdown_document` (whole file as one record) and `markdown_sections` (one record per `## ` section, falling back to one whole-document record when no sections exist). Source values such as `ke`, `decision`, `memory`, `rule`, `spec`, and `backlog` are preserved from the manifest and are filterable via `--source`.
 
 ### Key Design Decisions
 
@@ -100,9 +100,11 @@ Configurable in `[sources]` section of `backscroll.toml`. Source types: `ke`, `d
 - **External FTS5**: Uses `search_items` as content table with SQLite triggers, `snippet()` extraction, and Porter stemmer tokenizer for morphological matching.
 - **Incremental sync**: SHA-256 hash per file stored in `indexed_files` table; unchanged files are skipped.
 - **Plan indexing**: Markdown plans from `~/.claude/plans/` split by `##` headers, each section indexed as a separate search item with `source='plan'`.
-- **Source filtering**: `search_items.source` column distinguishes sessions from plans; `--source` flag filters at query time.
+- **Declarative Markdown inputs**: `markdown_document` and `markdown_sections` readers reuse `internal/sources` parsers, flow through the normal input manifest registry/autosync path, and store the manifest `source` value on indexed rows. They do not parse YAML frontmatter into structured metadata.
+- **Source filtering**: `search_items.source` column distinguishes sessions, plans, and declarative source types; `--source` flag filters at query time.
 - **Date filtering**: `--after`/`--before` flags filter by `search_items.timestamp` with NULL-safe guards; `--before` uses exclusive `<` comparison.
 - **Multi-path config**: `SessionDirs []string` with backward-compatible `session_dir` alias and auto-discovery of `~/.claude/projects/`.
+- **Legacy `[sources]` migration boundary**: Any `[sources]` table in the global `config.toml` or local `./backscroll.toml` is a hard preflight error before executable commands perform database or file side effects. Help and version remain available. Migrate each key to an active `*.inputs.toml` manifest under `<config_dir>/backscroll/inputs/`: `ke` → `source = "ke"`, `decode.format = "markdown_document"`; `memories` → `source = "memory"`, `markdown_document`; `decisions` → `source = "decision"`, `markdown_sections`; `rules` → `source = "rule"`, `markdown_sections`; `specs` → `source = "spec"`, `markdown_sections`; `backlog` → `source = "backlog"`, `markdown_sections`.
 - **Auto-tagging**: Regex heuristics in `internal/tagging` detect session categories (debugging, refactoring, feature, testing, docs, config) during sync; stored in `session_tags` table.
 - **Content-type classification**: Messages classified as `text`/`code`/`tool`/`reasoning` based on message content types during sync. Tool content is indexed in separate `search_items` rows with `content_type='tool'`. Pi agent reasoning blocks are captured when `index_reasoning=true` (default off) in the input manifest and indexed with `content_type='reasoning'`. Sync writes only to `search_items`; the `session_events` table was dropped in migration v5.
 - **Split FTS by retrieval semantics**: tool content (`content_type='tool'`) lives in a separate FTS5 index `tool_fts` (tokenizer `trigram`, substring/exact match for paths/commands/errors); prose content (text, code, reasoning) lives in `messages_fts` (`porter unicode61`). Migration v4 branched the triggers by content type. Migration v7 updated the triggers to route 'reasoning' alongside 'text'/'code' to `messages_fts`. `--content-type tool` queries `tool_fts`; prose queries `messages_fts`; an unfiltered query merges both via Reciprocal Rank Fusion (RRF, k=60), which fuses by rank position, not score magnitude, and is immune to incomparable cross-tokenizer BM25 scales. The trigram tokenizer matches substrings of ≥3 characters, so tool queries shorter than 3 characters will match zero results.
@@ -221,6 +223,6 @@ github.com/pablontiv/backscroll/internal/sequences     — F4 PrefixSpan mining 
 github.com/pablontiv/backscroll/internal/storage       — Database schema, migrations v1–v13, FTS5 indexes
 github.com/pablontiv/backscroll/internal/projects      — Project identity registry
 github.com/pablontiv/backscroll/internal/reader        — Direct session file reader
-github.com/pablontiv/backscroll/internal/readers       — SessionReader interface, Registry, ClaudeReader (text+tool_use+tool_result), PiReader (text+toolCall+custom results), OpenCodeReader (text+tool state.input+state.output); toolfmt serializer
+github.com/pablontiv/backscroll/internal/readers       — SessionReader interface, Registry, ClaudeReader (text+tool_use+tool_result), PiReader (text+toolCall+custom results), OpenCodeReader (text+tool state.input+state.output), MarkdownDocumentReader (`markdown_document`), MarkdownSectionsReader (`markdown_sections`); toolfmt serializer
 github.com/pablontiv/backscroll/internal/recovery      — Stranded database recovery orchestration, durable backup, and atomic replacement
 ```

--- a/cmd/backscroll/legacy_sources_test.go
+++ b/cmd/backscroll/legacy_sources_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/backscroll/internal/config"
+)
+
+func TestLegacySourcesBlockEveryExecutableCommand(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "search", args: []string{"search"}},
+		{name: "read", args: []string{"read", "--path", missingPath}},
+		{name: "list", args: []string{"list"}},
+		{name: "patterns", args: []string{"patterns", "--kind", "commands"}},
+		{name: "rebuild", args: []string{"rebuild"}},
+		{name: "purge", args: []string{"purge", "--before", "2026-01-01"}},
+		{name: "validate", args: []string{"validate", "--indexed-only"}},
+		{name: "status", args: []string{"status"}},
+		{name: "config", args: []string{"config"}},
+		{name: "annotate", args: []string{"annotate", "--uuid", "test-uuid", "--kind", "correction", "--label", "false-positive"}},
+		{name: "recover", args: []string{"recover", "--from", missingPath}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacySourcesCLIEnv(t)
+
+			_, _, err := executeLegacySourcesCmd(tt.args...)
+			if err == nil {
+				t.Fatalf("%v returned nil error, want *config.LegacySourcesError", tt.args)
+			}
+			var legacyErr *config.LegacySourcesError
+			if !errors.As(err, &legacyErr) {
+				t.Fatalf("%v error = %T %[2]v, want *config.LegacySourcesError", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestLegacySourcesPreflightHasNoSideEffects(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "search", args: []string{"search"}},
+		{name: "read", args: []string{"read", "--path", missingPath}},
+		{name: "list", args: []string{"list"}},
+		{name: "patterns", args: []string{"patterns", "--kind", "commands"}},
+		{name: "rebuild", args: []string{"rebuild"}},
+		{name: "purge", args: []string{"purge", "--before", "2026-01-01"}},
+		{name: "validate", args: []string{"validate", "--indexed-only"}},
+		{name: "status", args: []string{"status"}},
+		{name: "config", args: []string{"config"}},
+		{name: "annotate", args: []string{"annotate", "--uuid", "test-uuid", "--kind", "correction", "--label", "false-positive"}},
+		{name: "recover", args: []string{"recover", "--from", missingPath}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbPath := legacySourcesCLIEnv(t)
+
+			_, _, err := executeLegacySourcesCmd(tt.args...)
+			if err == nil {
+				t.Fatalf("%v returned nil error, want *config.LegacySourcesError", tt.args)
+			}
+			var legacyErr *config.LegacySourcesError
+			if !errors.As(err, &legacyErr) {
+				t.Fatalf("%v error = %T %[2]v, want *config.LegacySourcesError", tt.args, err)
+			}
+			if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+				t.Fatalf("database path stat error = %v, want not exist at %s", statErr, dbPath)
+			}
+		})
+	}
+}
+
+func TestLegacySourcesAllowsHelpAndVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "root help", args: []string{"--help"}, want: "Available Commands:"},
+		{name: "root version", args: []string{"--version"}, want: "backscroll"},
+		{name: "subcommand help", args: []string{"search", "--help"}, want: "Search performs a hybrid search"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacySourcesCLIEnv(t)
+
+			stdout, stderr, err := executeLegacySourcesCmd(tt.args...)
+			if err != nil {
+				t.Fatalf("%v returned error: %v\nstderr=%s", tt.args, err, stderr)
+			}
+			out := stdout + stderr
+			if !strings.Contains(out, tt.want) {
+				t.Fatalf("%v output = %q, want it to contain %q", tt.args, out, tt.want)
+			}
+		})
+	}
+}
+
+func legacySourcesCLIEnv(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	configBase := filepath.Join(root, "config")
+	wd := filepath.Join(root, "work")
+	for _, path := range []string{home, configBase, wd} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", path, err)
+		}
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("BACKSCROLL_CONFIG_DIR", configBase)
+	dbPath := filepath.Join(root, "missing", "backscroll.db")
+	t.Setenv("BACKSCROLL_DATABASE_PATH", dbPath)
+	t.Chdir(wd)
+
+	globalConfig := filepath.Join(home, ".config", "backscroll", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(globalConfig), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(globalConfig), err)
+	}
+	if err := os.WriteFile(globalConfig, []byte("[sources]\nke = [\"legacy-ke\"]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", globalConfig, err)
+	}
+
+	return dbPath
+}
+
+func executeLegacySourcesCmd(args ...string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	root := buildRootCmd(&stdout, &stderr)
+	root.SetArgs(args)
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}

--- a/cmd/backscroll/main.go
+++ b/cmd/backscroll/main.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/pablontiv/picokit/autoupdate"
 	"github.com/spf13/cobra"
+
+	"github.com/pablontiv/backscroll/internal/config"
+	"github.com/pablontiv/backscroll/internal/input_config"
 )
 
 var version = "dev"
@@ -76,6 +79,13 @@ Prose and tool activity are indexed separately — a Porter-stemmed FTS5 index f
 conversation, a trigram index for commands, paths and errors — and an unfiltered
 query merges both by rank position (RRF).`,
 		Version: version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			inputsDir, err := input_config.InputsDir()
+			if err != nil {
+				return fmt.Errorf("resolve inputs directory: %w", err)
+			}
+			return config.ValidateNoLegacySources(inputsDir)
+		},
 	}
 	root.SetOut(stdout)
 	root.SetErr(stderr)

--- a/cmd/backscroll/markdown_inputs_test.go
+++ b/cmd/backscroll/markdown_inputs_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/backscroll/internal/storage"
+)
+
+func TestDeclarativeMarkdownSectionsAutoSyncAndSearch(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	configDir := filepath.Join(tmp, "config")
+	workDir := filepath.Join(tmp, "work")
+	decisionRoot := filepath.Join(tmp, "decisions")
+	dbPath := filepath.Join(tmp, "backscroll.db")
+
+	for _, path := range []string{homeDir, configDir, workDir, decisionRoot} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("BACKSCROLL_CONFIG_DIR", configDir)
+	t.Setenv("BACKSCROLL_DATABASE_PATH", dbPath)
+	t.Chdir(workDir)
+
+	inputsDir := filepath.Join(configDir, "backscroll", "inputs")
+	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
+		t.Fatalf("mkdir inputs dir: %v", err)
+	}
+	manifest := fmt.Sprintf(`version = 1
+
+[[inputs]]
+id = "decisions-e2e"
+source = "decision"
+active = true
+
+[inputs.discover]
+roots = [%q]
+include = ["**/*.md"]
+exclude = []
+follow_symlinks = false
+
+[inputs.decode]
+format = "markdown_sections"
+`, decisionRoot)
+	manifestPath := filepath.Join(inputsDir, "decisions.inputs.toml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	uniqueTerm := "hyperionfluxneedle"
+	decisionPath := filepath.Join(decisionRoot, "adr-0001.md")
+	decisionMarkdown := fmt.Sprintf(`# ADR 0001
+
+## Accepted Migration
+
+Use the declarative markdown_sections reader for %s decisions.
+
+## Rejected Context
+
+This section must not be returned by a section-filtered search.
+`, uniqueTerm)
+	if err := os.WriteFile(decisionPath, []byte(decisionMarkdown), 0o644); err != nil {
+		t.Fatalf("write decision markdown: %v", err)
+	}
+
+	stdout, stderr, err := executeMarkdownInputsCmd("search", "--all-projects", "--source", "decision", uniqueTerm)
+	if err != nil {
+		t.Fatalf("first search error: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "Source: decision") {
+		t.Fatalf("search output missing source filter evidence; stdout=%s", stdout)
+	}
+	if !strings.Contains(stdout, "## Accepted Migration") || !strings.Contains(stdout, uniqueTerm) {
+		t.Fatalf("search output missing expected matching section; stdout=%s", stdout)
+	}
+	if strings.Contains(stdout, "## Rejected Context") {
+		t.Fatalf("search output included non-matching section, want markdown_sections isolation; stdout=%s", stdout)
+	}
+
+	before := countMarkdownInputRows(t, dbPath)
+	stdout, stderr, err = executeMarkdownInputsCmd("search", "--all-projects", "--source", "decision", uniqueTerm)
+	if err != nil {
+		t.Fatalf("second search error: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	after := countMarkdownInputRows(t, dbPath)
+	if after != before {
+		t.Fatalf("second autosync changed indexed counts: before=%+v after=%+v", before, after)
+	}
+}
+
+type markdownInputCounts struct {
+	IndexedFiles int
+	SearchItems  int
+}
+
+func countMarkdownInputRows(t *testing.T, dbPath string) markdownInputCounts {
+	t.Helper()
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db for counts: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close db for counts: %v", err)
+		}
+	}()
+
+	var counts markdownInputCounts
+	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM indexed_files`).Scan(&counts.IndexedFiles); err != nil {
+		t.Fatalf("count indexed_files: %v", err)
+	}
+	if err := db.DB().QueryRow(`SELECT COUNT(*) FROM search_items`).Scan(&counts.SearchItems); err != nil {
+		t.Fatalf("count search_items: %v", err)
+	}
+	return counts
+}
+
+func executeMarkdownInputsCmd(args ...string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	root := buildRootCmd(&stdout, &stderr)
+	root.SetArgs(args)
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}

--- a/cmd/backscroll/markdown_registry_test.go
+++ b/cmd/backscroll/markdown_registry_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pablontiv/backscroll/internal/input_config"
+)
+
+func TestDefaultAutoSyncRegistryIncludesMarkdownReaders(t *testing.T) {
+	reg := newDefaultAutoSyncRegistry()
+
+	for _, format := range []string{"markdown_document", "markdown_sections"} {
+		t.Run(format, func(t *testing.T) {
+			reader, err := reg.ForDef(input_config.InputDefinition{Decode: input_config.DecodeConfig{Format: format}})
+			if err != nil {
+				t.Fatalf("ForDef(%q) error = %v", format, err)
+			}
+			if reader.Name() != format {
+				t.Fatalf("reader.Name() = %q, want %q", reader.Name(), format)
+			}
+		})
+	}
+}

--- a/cmd/backscroll/sync_helpers.go
+++ b/cmd/backscroll/sync_helpers.go
@@ -27,6 +27,8 @@ func newDefaultAutoSyncRegistry() *readers.Registry {
 	reg.Register(&readers.OpenCodeReader{})
 	reg.Register(&readers.ClaudeReader{})
 	reg.Register(&readers.PiReader{})
+	reg.Register(&readers.MarkdownDocumentReader{})
+	reg.Register(&readers.MarkdownSectionsReader{})
 	return reg
 }
 

--- a/docs/superpowers/plans/2026-08-19-legacy-sources-migration.md
+++ b/docs/superpowers/plans/2026-08-19-legacy-sources-migration.md
@@ -1,0 +1,482 @@
+# Legacy Sources Migration and Markdown Inputs Implementation Plan
+
+> **For implementer:** REQUIRED SUB-SKILL: Use `test-driven-development` for every behavior change. Execute in the isolated worktree `/Users/Shared/harness/.worktrees/backscroll-issue-31` on branch `fix/issue-31-upgrade-sources-migration`. Commit each task independently. After each task, run an independent requirements/code-quality review before starting the next task.
+
+**Goal:** Make upgrades with legacy `[sources]` fail loudly before every executable command, while providing working declarative `markdown_document` and `markdown_sections` readers as the supported migration destination.
+
+**Architecture:** A config-layer validator inspects global and local TOML files for the table's presence and returns a structured deterministic migration error. A root Cobra `PersistentPreRunE` invokes it before any command side effects. Two format-specific Markdown readers reuse the existing source parsers and enter the normal reader registry, incremental hash, `SyncFiles`, and FTS path.
+
+**Tech Stack:** Go, Cobra, go-toml/v2, picokit/hashfile, SQLite/FTS5 integration tests, stdlib `testing`.
+
+**Design:** `docs/superpowers/specs/2026-08-19-legacy-sources-migration-design.md`
+
+---
+
+## Global execution rules
+
+- Follow red-green-refactor for each task: add a failing test, run it and observe the expected failure, implement the minimum behavior, rerun the focused tests, then commit.
+- Keep tests hermetic with `t.Setenv("HOME", t.TempDir())`, `t.Setenv("BACKSCROLL_CONFIG_DIR", ...)`, `t.Setenv("BACKSCROLL_DATABASE_PATH", ...)`, and `t.Chdir(...)` where relevant.
+- Do not alter migrations. The `source_metadata` lineage is already fixed by #34.
+- Do not restore the legacy `sources.ParseAll` production path.
+- Do not add a `sync` command or auto-generate manifests.
+- Preserve unrelated work and do not implement issue #33 beyond behavior required to make the approved #31 migration target functional.
+
+## Task 1: Reject legacy source configuration deterministically
+
+**Files:**
+- Create: `internal/config/legacy_sources.go`
+- Create: `internal/config/legacy_sources_test.go`
+- Reference: `internal/config/config.go`
+
+### Step 1: Write the failing validator tests
+
+Add table-driven tests covering:
+
+```go
+func TestValidateNoLegacySourcesReportsAllConfigFiles(t *testing.T)
+func TestValidateNoLegacySourcesRejectsEmptyTable(t *testing.T)
+func TestValidateNoLegacySourcesIgnoresMissingFiles(t *testing.T)
+func TestValidateNoLegacySourcesReportsMalformedTOML(t *testing.T)
+```
+
+Use an isolated HOME for the global file and `t.Chdir` for `./backscroll.toml`. Assert:
+
+- global and local files are both included, in that order;
+- configured keys are sorted as `backlog, decisions, ke, memories, rules, specs`;
+- an empty table reports `keys: none`;
+- the caller-supplied inputs directory appears in the message;
+- `markdown_document` and `markdown_sections` appear in the message;
+- missing files succeed;
+- malformed TOML reports its path.
+
+Use `errors.As` to assert a typed `*LegacySourcesError` and inspect its structured entries rather than testing only substrings.
+
+### Step 2: Run the focused tests and observe failure
+
+```bash
+go test ./internal/config -run 'TestValidateNoLegacySources' -count=1
+```
+
+Expected: compile failure because `ValidateNoLegacySources` and `LegacySourcesError` do not exist.
+
+### Step 3: Implement the minimum validator
+
+In `internal/config/legacy_sources.go`, add:
+
+```go
+type LegacySourcesFile struct {
+    Path string
+    Keys []string
+}
+
+type LegacySourcesError struct {
+    Files     []LegacySourcesFile
+    InputsDir string
+}
+
+func (e *LegacySourcesError) Error() string
+func ValidateNoLegacySources(inputsDir string) error
+```
+
+Implementation requirements:
+
+- inspect `globalConfigPath()` then `./backscroll.toml`;
+- ignore `os.IsNotExist` only;
+- unmarshal a minimal envelope with `Sources *SourcesConfig` so an empty table is detectable;
+- collect every offending file before returning;
+- derive only non-empty known keys;
+- sort keys lexicographically;
+- produce one deterministic message with migration mappings and no terminal styling;
+- wrap read/TOML errors with the path.
+
+Do not call `sources.ParseAll`, mutate `Config`, or touch the database.
+
+### Step 4: Run focused and package tests
+
+```bash
+go test ./internal/config -run 'TestValidateNoLegacySources' -count=1
+go test ./internal/config -count=1
+```
+
+Expected: PASS.
+
+### Step 5: Commit
+
+```bash
+git add internal/config/legacy_sources.go internal/config/legacy_sources_test.go
+git commit -m "fix(config): reject legacy sources tables"
+```
+
+### Task 1 review checkpoint
+
+An independent reviewer must verify:
+
+- table presence, not merely non-empty values, triggers rejection;
+- both config locations are reported;
+- ordering and message output are deterministic;
+- missing files are the only ignored read error;
+- no ingestion or DB behavior was added.
+
+Resolve all confirmed findings and obtain re-review before Task 2.
+
+## Task 2: Enforce the migration boundary before every command
+
+**Files:**
+- Modify: `cmd/backscroll/main.go`
+- Create: `cmd/backscroll/legacy_sources_test.go`
+- Reference: `cmd/backscroll/read.go`
+- Reference: `cmd/backscroll/recover.go`
+- Reference: `cmd/backscroll/config.go`
+- Reference: `internal/input_config/loader.go`
+
+### Step 1: Write failing CLI preflight tests
+
+Create helpers that write a legacy global config under the isolated HOME and execute `buildRootCmd` directly.
+
+Add:
+
+```go
+func TestLegacySourcesBlockEveryExecutableCommand(t *testing.T)
+func TestLegacySourcesPreflightHasNoSideEffects(t *testing.T)
+func TestLegacySourcesAllowsHelpAndVersion(t *testing.T)
+```
+
+Table-test these syntactically valid invocations:
+
+```text
+search
+read --path <missing-path>
+list
+patterns --kind commands
+rebuild
+purge --before 2026-01-01
+validate --indexed-only
+status
+config
+annotate --uuid test-uuid --kind correction --label false-positive
+recover --from <missing-path>
+```
+
+For every executable command, assert the returned error is or wraps `*config.LegacySourcesError`. For side effects, point `BACKSCROLL_DATABASE_PATH` at a nonexistent temp path and assert it remains absent; also assert `read` and `recover` fail with the migration error rather than their missing-path errors.
+
+Verify these remain successful and contain normal help/version output:
+
+```text
+--help
+--version
+search --help
+```
+
+### Step 2: Run the focused tests and observe failure
+
+```bash
+go test ./cmd/backscroll -run 'TestLegacySources' -count=1
+```
+
+Expected: executable commands proceed past root dispatch; at least `read` returns its missing-file error instead of the migration error.
+
+### Step 3: Add the root preflight
+
+In `buildRootCmd`, add a `PersistentPreRunE` that:
+
+```go
+inputsDir, err := input_config.InputsDir()
+if err != nil {
+    return fmt.Errorf("resolve inputs directory: %w", err)
+}
+return config.ValidateNoLegacySources(inputsDir)
+```
+
+Import `internal/config` and `internal/input_config` in `main.go`. Do not open the database, load active inputs, or duplicate validator formatting in the command package.
+
+### Step 4: Run focused and command tests
+
+```bash
+go test ./cmd/backscroll -run 'TestLegacySources' -count=1
+go test ./cmd/backscroll -count=1
+```
+
+Expected: PASS.
+
+### Step 5: Commit
+
+```bash
+git add cmd/backscroll/main.go cmd/backscroll/legacy_sources_test.go
+git commit -m "fix(cli): block commands with legacy sources"
+```
+
+### Task 2 review checkpoint
+
+An independent reviewer must verify:
+
+- every executable subcommand inherits the hook;
+- argument sets are valid enough to reach the hook;
+- the hook runs before database, source-file, and recovery effects;
+- help/version remain usable;
+- errors preserve the typed config error with `%w` where wrapping occurs.
+
+Resolve all confirmed findings and obtain re-review before Task 3.
+
+## Task 3: Add whole-document and sectioned Markdown readers
+
+**Files:**
+- Create: `internal/readers/markdown_reader.go`
+- Create: `internal/readers/markdown_reader_test.go`
+- Modify: `cmd/backscroll/sync_helpers.go`
+- Modify: `cmd/backscroll/main_test.go` or create `cmd/backscroll/markdown_registry_test.go`
+- Reference: `internal/readers/reader.go`
+- Reference: `internal/sources/sources.go`
+- Reference: `internal/input_config/discover.go`
+
+### Step 1: Write failing reader tests
+
+Add tests:
+
+```go
+func TestMarkdownDocumentReaderParse(t *testing.T)
+func TestMarkdownSectionsReaderParse(t *testing.T)
+func TestMarkdownSectionsReaderFallsBackToDocument(t *testing.T)
+func TestMarkdownReaderDiscoverAndHash(t *testing.T)
+func TestMarkdownReaderReportsPathErrors(t *testing.T)
+```
+
+Use fixed file modtimes with `os.Chtimes`. Assert:
+
+- format names are exactly `markdown_document` and `markdown_sections`;
+- document mode returns one record containing the full document;
+- section mode returns one record per `## ` section using existing parser semantics;
+- no-section mode returns one trimmed whole-document record;
+- `Role == "document"`, `ContentType == "text"`, and `UUID == ""`;
+- every record uses the file modification time;
+- `ParsedFile.Path`, SHA-256 `Hash`, and parent-directory `Cwd` are correct;
+- discovery honors roots, includes, and excludes;
+- missing file errors include the path.
+
+Add a failing command-package test:
+
+```go
+func TestDefaultAutoSyncRegistryIncludesMarkdownReaders(t *testing.T)
+```
+
+Resolve both formats through `newDefaultAutoSyncRegistry().ForDef(...)`.
+
+### Step 2: Run the focused tests and observe failure
+
+```bash
+go test ./internal/readers ./cmd/backscroll -run 'TestMarkdown|TestDefaultAutoSyncRegistryIncludesMarkdown' -count=1
+```
+
+Expected: compile failure because Markdown readers do not exist, or registry lookup failure for both formats.
+
+### Step 3: Implement shared Markdown parsing
+
+In `internal/readers/markdown_reader.go`, provide two constructors or concrete readers with stable names. Share private logic to avoid duplicating discovery, hashing, stat, and source-item mapping.
+
+Requirements:
+
+- `Discover` calls `input_config.DiscoverFiles`;
+- `Hash` calls `hashfile.HashFile`;
+- `Parse` hashes and stats the path, then calls `sources.ParseDocument` or `sources.ParseSectioned` with `def.Source`;
+- each item maps to one `models.Message` with approved role/content type/modtime/empty UUID;
+- returned CWD is `filepath.Dir(path)`;
+- contextual errors include the operation and path.
+
+Do not parse structured frontmatter into messages, generate UUIDs, or add storage code.
+
+### Step 4: Register both formats
+
+In `newDefaultAutoSyncRegistry`, register the two Markdown reader instances alongside the three existing readers.
+
+### Step 5: Run focused, reader, and command tests
+
+```bash
+go test ./internal/readers -count=1
+go test ./cmd/backscroll -run 'TestDefaultAutoSyncRegistryIncludesMarkdown|TestMaybeAutoSync' -count=1
+go test ./cmd/backscroll -count=1
+```
+
+Expected: PASS.
+
+### Step 6: Commit
+
+```bash
+git add internal/readers/markdown_reader.go internal/readers/markdown_reader_test.go cmd/backscroll/sync_helpers.go cmd/backscroll/markdown_registry_test.go
+git commit -m "feat(readers): support declarative markdown inputs"
+```
+
+Adjust the final `git add` file list if the registry test is placed in an existing test file.
+
+### Task 3 review checkpoint
+
+An independent reviewer must verify:
+
+- the reader uses existing source parser semantics rather than introducing a second Markdown parser;
+- hash/modtime/path behavior is deterministic;
+- source classification remains `def.Source` in `maybeAutoSync`;
+- empty UUID correctly retains mutable non-session wipe-and-reload behavior;
+- no unsupported frontmatter claims or invented metadata appear.
+
+Resolve all confirmed findings and obtain re-review before Task 4.
+
+## Task 4: Prove declarative ingestion and publish migration guidance
+
+**Files:**
+- Create: `cmd/backscroll/markdown_inputs_test.go`
+- Modify: `inputs/decisions.inputs.toml`
+- Modify: `CLAUDE.md`
+- Modify if needed: `internal/config/legacy_sources.go`
+
+### Step 1: Write the failing end-to-end test
+
+Add:
+
+```go
+func TestDeclarativeMarkdownSectionsAutoSyncAndSearch(t *testing.T)
+```
+
+Hermetic setup:
+
+1. isolate HOME and working directory;
+2. set `BACKSCROLL_CONFIG_DIR` and `BACKSCROLL_DATABASE_PATH`;
+3. create `<config-dir>/backscroll/inputs/decisions.inputs.toml` with one active input, an absolute root, `source = "decision"`, `include = ["**/*.md"]`, and `decode.format = "markdown_sections"`;
+4. create a decision Markdown file with two `## ` sections and a unique search term;
+5. execute the real command path with `buildRootCmd` and `search --all-projects --source decision <unique-term>` (use the command's actual query flag syntax);
+6. assert the expected section and source are returned;
+7. execute the same command again and assert indexed row/file counts are unchanged.
+
+Use direct DB queries only for the idempotency counts. Do not mock the registry, discovery, parser, or `SyncFiles`.
+
+### Step 2: Run the focused test and observe the expected state
+
+```bash
+go test ./cmd/backscroll -run 'TestDeclarativeMarkdownSectionsAutoSyncAndSearch' -count=1
+```
+
+If Task 3 already makes the behavior pass, record that the test is characterization coverage added after the unit-level red-green implementation; do not introduce unnecessary production changes merely to force a failure.
+
+### Step 3: Correct the shipped preset
+
+Update `inputs/decisions.inputs.toml` comments:
+
+- keep `active = false`;
+- remove `backscroll sync`;
+- explain automatic sync before index-consuming commands;
+- state that sections headed by `## ` are indexed;
+- remove claims that YAML frontmatter is parsed into structured metadata.
+
+### Step 4: Update project documentation
+
+In `CLAUDE.md`:
+
+- update the implemented/readers descriptions to include `markdown_document` and `markdown_sections`;
+- update the Module Layout readers line;
+- update the Package Layout readers line;
+- document the legacy `[sources]` hard-error migration boundary and the key-to-format mapping in Key Design Decisions;
+- keep the migration count at v13 and do not describe a schema change.
+
+### Step 5: Run focused regressions
+
+```bash
+go test ./cmd/backscroll -run 'TestDeclarativeMarkdownSectionsAutoSyncAndSearch|TestLegacySources' -count=1
+go test ./internal/compat -run 'TestInspectIndexUsesObservedShapeNotVersionAlone' -count=1
+go test ./internal/storage -run 'TestMigration.*NoSourceMetadata|TestMigrationPlan' -count=1
+```
+
+If the final storage regex matches no exact test name, run the relevant `internal/storage` migration-plan tests by their actual names discovered with `go test ./internal/storage -list 'Migration'`.
+
+Expected: PASS, including the #34 no-`source_metadata` behavior.
+
+### Step 6: Commit
+
+```bash
+git add cmd/backscroll/markdown_inputs_test.go inputs/decisions.inputs.toml CLAUDE.md
+git commit -m "docs(config): guide markdown source migration"
+```
+
+Include any tightly related test-helper adjustment in the same commit and document why.
+
+### Task 4 review checkpoint
+
+An independent reviewer must verify:
+
+- the test crosses manifest loading, discovery, reader selection, sync, and source-filtered search;
+- the second run proves hash-based idempotency;
+- the preset does not promise nonexistent commands or frontmatter semantics;
+- CLAUDE.md package/module inventories remain accurate;
+- issue #31's already-fixed migration half is not reimplemented.
+
+Resolve all confirmed findings and obtain re-review before final verification.
+
+## Task 5: Whole-branch review and verification
+
+**Files:**
+- Review: all changes in `origin/main...HEAD`
+- Modify: only files required by confirmed review findings
+
+### Step 1: Run an independent whole-branch review
+
+Review against:
+
+- issue #31;
+- approved design;
+- this implementation plan;
+- project coverage and hermetic-test requirements;
+- the constraint that every issue ships through its own PR.
+
+Classify findings as blocking, important, or optional. Fix confirmed blocking/important findings, then obtain independent re-review.
+
+### Step 2: Run formatting and static checks
+
+```bash
+just check
+git diff --check origin/main...HEAD
+```
+
+Expected: PASS and no whitespace errors.
+
+### Step 3: Run the full test and CI gates fresh
+
+```bash
+just test
+just ci
+```
+
+Expected: PASS with aggregate statement coverage at or above 85%.
+
+### Step 4: Inspect final branch scope
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff --name-status origin/main...HEAD
+```
+
+Expected:
+
+- clean working tree;
+- only #31 design, plan, config preflight, Markdown readers, tests, preset, and CLAUDE documentation;
+- no #35 commits or unrelated harness work;
+- branch based directly on `origin/main`.
+
+### Step 5: Commit any final review fixes
+
+If review required changes:
+
+```bash
+git add <confirmed-fix-files>
+git commit -m "fix: address legacy sources review findings"
+```
+
+Then rerun Steps 2–4. Never claim completion from cached or pre-fix output.
+
+### Step 6: Prepare the dedicated PR
+
+Push only after verification and open a dedicated PR for #31. The PR body must:
+
+- use the repository template;
+- include `Fixes #31`;
+- state that #34 already resolved the missing-`source_metadata` migration lineage;
+- explain that this PR rejects legacy `[sources]` and makes both Markdown manifest formats functional;
+- include exact `just check` and `just ci` evidence;
+- mention that #33 will be classified separately after this PR.

--- a/docs/superpowers/specs/2026-08-19-legacy-sources-migration-design.md
+++ b/docs/superpowers/specs/2026-08-19-legacy-sources-migration-design.md
@@ -1,0 +1,296 @@
+# Legacy Sources Migration and Markdown Inputs Design
+
+**Date:** 2026-08-19
+**Issue:** [#31 — upgrade from a 0.3.x database is not seamless](https://github.com/pablontiv/backscroll/issues/31)
+
+## Summary
+
+Issue #31 reported two upgrade regressions from 0.3.18 to v3.2.5:
+
+1. V6 attempted to drop `search_items.source_metadata` from a released lineage that never had the column.
+2. The legacy `[sources]` table remained accepted by `config.toml` but was no longer consumed, silently dropping decision and knowledge-source ingestion.
+
+The first regression is already resolved on `main` by #34. Compatibility planning now inspects the actual schema shape and skips V6 when `source_metadata` is absent. This design does not change migrations.
+
+The remaining regression will be handled as an explicit migration boundary. Any legacy `[sources]` table will make every executable subcommand fail before database or source side effects, with deterministic instructions to migrate to `*.inputs.toml`. The migration destination will be made functional by adding declarative readers for whole-document and sectioned Markdown inputs.
+
+## Goals
+
+- Never silently ignore a legacy `[sources]` table.
+- Block every executable subcommand when `[sources]` is present, including `config`, `read`, and `recover`.
+- Report every config file containing `[sources]`, its configured keys, and the declarative input directory.
+- Keep `--help` and `--version` available for diagnosis.
+- Make `decode.format = "markdown_sections"` and `decode.format = "markdown_document"` functional in the normal reader/autosync pipeline.
+- Preserve source classification through `InputDefinition.Source` (`decision`, `ke`, `memory`, `rule`, `spec`, or `backlog`).
+- Correct the shipped decisions preset so its instructions match the current CLI and parser behavior.
+- Preserve the schema-shape migration behavior already delivered by #34.
+- Deliver the change through a dedicated PR for issue #31.
+
+## Non-goals
+
+- Restoring the legacy `[sources]` ingestion path.
+- Automatically rewriting `config.toml` or generating manifests.
+- Supporting glob syntax inside legacy `[sources]` values.
+- Adding a `sync` command.
+- Parsing or indexing YAML frontmatter fields as structured metadata.
+- Changing SQLite schema, migrations, recovery, or perennial lifecycle rules.
+- Activating the shipped decisions preset by default.
+
+## Existing State
+
+### Database compatibility
+
+`internal/compat.remainingStepsFor` already omits migration V6 when the inspected shape lacks `source_metadata`. Existing compatibility tests distinguish otherwise-equivalent V5/V3 lineages by observed columns, and migration application remains atomic.
+
+No new compatibility mechanism is needed. The issue #31 PR will retain and execute the existing regression coverage rather than modifying migration code.
+
+### Legacy configuration
+
+`internal/config.Config` still contains `Sources SourcesConfig`, and `loadConfigFile` still merges its values. No production caller reads `cfg.Sources`, so a valid-looking configuration is silently ignored.
+
+### Declarative Markdown inputs
+
+`inputs/decisions.inputs.toml` declares `decode.format = "markdown_sections"`. `newDefaultAutoSyncRegistry` registers only Claude, Pi, and OpenCode readers, so activating the preset fails with `no reader registered for format "markdown_sections"`.
+
+The preset also instructs users to run the removed `backscroll sync` command and claims structured frontmatter behavior that the current source parser does not provide.
+
+## Design
+
+### 1. Legacy configuration detection
+
+Add a config-layer validator:
+
+```go
+func ValidateNoLegacySources(inputsDir string) error
+```
+
+The validator will inspect the same two config locations used by `config.Load`, in resolution order:
+
+1. global `config.toml`;
+2. local `./backscroll.toml`.
+
+It will parse a minimal TOML envelope with a pointer-valued `Sources` field. A non-nil pointer means the `[sources]` table exists; even an empty table is unsupported and must fail.
+
+The validator will collect all offending files rather than stopping at the first. For each file it records configured non-empty keys from this fixed vocabulary:
+
+```text
+backlog, decisions, ke, memories, rules, specs
+```
+
+Keys are sorted lexicographically, and files retain deterministic global-then-local order. An empty table is reported as `keys: none`.
+
+The returned typed error will contain structured entries and an `Error()` message suitable for direct CLI output. The message includes the canonical `inputsDir` supplied by the caller and the two supported migration formats:
+
+```text
+markdown_document
+markdown_sections
+```
+
+Missing config files are ignored. TOML syntax errors continue to be reported by normal config loading; the validator reports parse errors with the offending path rather than treating malformed TOML as legacy configuration.
+
+### 2. Global CLI preflight
+
+`buildRootCmd` will install a `PersistentPreRunE` hook that:
+
+1. resolves the canonical input directory with `input_config.InputsDir()`;
+2. calls `config.ValidateNoLegacySources(inputsDir)`;
+3. returns the error before the selected command's `RunE` executes.
+
+This makes the rejection uniform across all executable subcommands, including commands that currently bypass `config.Load`, such as `read`.
+
+Cobra's built-in help and version exits do not execute command hooks, so these diagnostic paths remain available:
+
+```bash
+backscroll --help
+backscroll --version
+backscroll <command> --help
+```
+
+The preflight runs before any database open, migration, autosync, recovery, or direct source read. There is no cached-index fallback for this configuration error.
+
+### 3. Markdown reader boundary
+
+Add a focused Markdown reader implementation in `internal/readers`. It will expose two registered formats:
+
+```text
+markdown_document
+markdown_sections
+```
+
+Both implement the existing `SessionReader` interface and reuse established components:
+
+- discovery: `input_config.DiscoverFiles`;
+- hashing: `hashfile.HashFile`;
+- parsing: `sources.ParseDocument` or `sources.ParseSectioned`;
+- source classification: `InputDefinition.Source`, applied later by `maybeAutoSync` to `storage.IndexedFile.Source`.
+
+A shared internal implementation may back two small constructors or reader types, but each registered instance has a stable `Name()` matching its decode format.
+
+### 4. Markdown record mapping
+
+Each parsed source item becomes one `models.Message`:
+
+```text
+Role:        document
+Content:     source item content
+ContentType: text
+Timestamp:   source file modification time
+UUID:        empty
+```
+
+The returned `models.ParsedFile` contains:
+
+```text
+Path: source file path
+Hash: SHA-256 from hashfile
+Cwd:  source file parent directory
+```
+
+An empty UUID is intentional. Markdown sources are mutable non-session inputs, so the existing `SyncFiles` wipe-and-reload path remains correct and idempotent by file hash.
+
+For `markdown_sections`, each `## ` section becomes a record. A file without `## ` sections becomes one whole-document record, preserving `sources.ParseSectioned` behavior. `markdown_document` always produces one record.
+
+File stat, hash, discovery, and parse errors are returned with path context. The reader does not invent structured frontmatter fields, stable message UUIDs, or section timestamps.
+
+### 5. Registry and autosync integration
+
+`newDefaultAutoSyncRegistry` will register both Markdown formats alongside Claude, Pi, and OpenCode.
+
+No parallel source-ingestion path will be added. Declarative Markdown definitions flow through the existing sequence:
+
+```text
+ActiveInputs
+  -> Registry.ForDef
+  -> Discover / Hash / Parse
+  -> storage.IndexedFile{Source: def.Source}
+  -> SyncFiles
+```
+
+This gives Markdown inputs the same incremental hashing, project identification, source filtering, and storage lifecycle as other inputs.
+
+### 6. Preset and migration guidance
+
+Update `inputs/decisions.inputs.toml` to:
+
+- keep `active = false`;
+- retain directory/glob discovery;
+- retain `decode.format = "markdown_sections"`;
+- remove the nonexistent `backscroll sync` instruction;
+- explain that active inputs sync automatically before index-consuming commands;
+- remove claims that YAML frontmatter is parsed into structured metadata.
+
+The legacy error and documentation will provide this mapping:
+
+| Legacy key | Declarative source | Decode format |
+|---|---|---|
+| `ke` | `ke` | `markdown_document` |
+| `memories` | `memory` | `markdown_document` |
+| `decisions` | `decision` | `markdown_sections` |
+| `rules` | `rule` | `markdown_sections` |
+| `specs` | `spec` | `markdown_sections` |
+| `backlog` | `backlog` | `markdown_sections` |
+
+The tool reports the migration; it does not perform it automatically.
+
+## Data Flow
+
+### Unsupported legacy configuration
+
+```text
+CLI invocation
+  -> root PersistentPreRunE
+  -> resolve InputsDir
+  -> inspect global + local config
+  -> [sources] found
+  -> deterministic migration error
+  -> command RunE never executes
+  -> no DB/source side effects
+```
+
+### Migrated declarative Markdown input
+
+```text
+*.inputs.toml
+  -> ActiveInputs
+  -> Markdown reader selected by decode.format
+  -> DiscoverFiles
+  -> hash + document/section parse
+  -> ParsedFile records
+  -> IndexedFile with def.Source
+  -> SyncFiles
+  -> FTS search by --source
+```
+
+## Error Handling
+
+- Missing config files: ignored.
+- Malformed config TOML during preflight: hard error with path; no command execution.
+- One or more `[sources]` tables: one deterministic hard error listing all offending files.
+- Unknown Markdown source type: the reader preserves `def.Source`; it does not enforce a closed source enum.
+- Unsupported decode format: existing `Registry.ForDef` error remains unchanged.
+- Missing/unreadable Markdown file: contextual reader error; autosync fails rather than silently skipping a configured source.
+- No Markdown sections: one whole-document text record.
+- Empty Markdown file: one empty document record, consistent with current `ParseDocument`/`ParseSectioned`; storage behavior remains deterministic.
+
+## Testing
+
+### Config validator
+
+- Detect a global `[sources]` table.
+- Detect a local `[sources]` table.
+- Report both files in deterministic order.
+- Reject an empty `[sources]` table.
+- Sort configured keys deterministically.
+- Include the supplied input directory and both Markdown formats in the error.
+- Ignore absent config files.
+- Preserve path context for malformed TOML.
+
+### CLI preflight
+
+Use direct `buildRootCmd` execution with an isolated HOME, config directory, working directory, and database path.
+
+- Table-test every executable subcommand with syntactically valid minimum arguments and require the legacy migration error.
+- Assert the database path and command-specific output files remain absent.
+- Prove `read` is blocked before opening its requested source file.
+- Prove `recover` is blocked before reading or replacing databases.
+- Prove `config` is blocked rather than displaying silently ignored values.
+- Prove root help, root version, and subcommand help remain available.
+
+### Markdown readers
+
+- `markdown_document` returns exactly one document record.
+- `markdown_sections` returns one record per `## ` section.
+- Section mode falls back to one record when no sections exist.
+- Role, content type, modtime, hash, path, cwd, and empty UUID are correct.
+- Discovery honors configured roots/globs.
+- Missing and unreadable files return contextual errors.
+- Registry resolves both exact format names.
+
+### End-to-end declarative ingestion
+
+Create a hermetic active decisions manifest and Markdown decision file, then run an index-consuming CLI command:
+
+- autosync discovers and parses the file;
+- `search --source decision` returns a unique section term;
+- a second invocation with unchanged hash is idempotent;
+- no legacy `[sources]` config is present.
+
+### Existing migration regression
+
+Run the existing compatibility tests that prove a released lineage without `source_metadata` skips V6 and reaches current schema. Do not duplicate migration code or alter migration fixtures unless a missing assertion is discovered.
+
+### Verification commands
+
+```bash
+just check
+just test
+just ci
+git diff --check origin/main...HEAD
+```
+
+## Documentation Impact
+
+- Add `MarkdownReader` to the `internal/readers` description in `CLAUDE.md` and Package Layout because the reader package's implemented formats change.
+- Update `inputs/decisions.inputs.toml` comments.
+- Keep issue #31 and PR text explicit that migration compatibility was delivered by #34 while this PR resolves the remaining silent configuration loss and repairs the documented migration target.
+- After this PR, re-evaluate issue #33. Its requested directory/glob model already exists; a working Markdown reader may satisfy the remaining observed failure.

--- a/inputs/decisions.inputs.toml
+++ b/inputs/decisions.inputs.toml
@@ -4,11 +4,16 @@
 # to enable indexing of architecture decision records.
 #
 # This preset discovers ADRs from docs/adr/ and docs/decisions/ directories
-# across configured project roots, parses YAML frontmatter (id, title, status, scope),
-# and indexes them with source = "decision" for decision-specific search and audit.
+# across configured project roots and indexes them with source = "decision" for
+# decision-specific search and audit.
 #
-# Install: cp decisions.inputs.toml ~/.config/backscroll/inputs/
-# Then: backscroll sync
+# Keep active = false until the roots below match your projects. Active inputs
+# are synchronized automatically before index-consuming commands such as search,
+# list, and patterns.
+#
+# decode.format = "markdown_sections" indexes each section headed by "## " as
+# a separate decision record. YAML frontmatter remains part of the Markdown text;
+# Backscroll does not parse it into structured metadata.
 #
 version = 1
 

--- a/internal/config/legacy_sources.go
+++ b/internal/config/legacy_sources.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// LegacySourcesFile describes one config file containing an unsupported [sources] table.
+type LegacySourcesFile struct {
+	Path string
+	Keys []string
+}
+
+// LegacySourcesError reports legacy [sources] tables and deterministic migration guidance.
+type LegacySourcesError struct {
+	Files     []LegacySourcesFile
+	InputsDir string
+}
+
+func (e *LegacySourcesError) Error() string {
+	var b strings.Builder
+
+	b.WriteString("legacy [sources] configuration is no longer supported; migrate to declarative input files")
+	if e.InputsDir != "" {
+		b.WriteString(" in ")
+		b.WriteString(e.InputsDir)
+	}
+	b.WriteString(".\n\n")
+
+	b.WriteString("Config files containing [sources]:\n")
+	for _, file := range e.Files {
+		b.WriteString("- ")
+		b.WriteString(file.Path)
+		b.WriteString(" (keys: ")
+		if len(file.Keys) == 0 {
+			b.WriteString("none")
+		} else {
+			b.WriteString(strings.Join(file.Keys, ", "))
+		}
+		b.WriteString(")\n")
+	}
+
+	b.WriteString("\nCreate *.inputs.toml definitions using decode.format = \"markdown_document\" or \"markdown_sections\".\n")
+	b.WriteString("Migration mapping:\n")
+	b.WriteString("- ke -> source = \"ke\", decode.format = \"markdown_document\"\n")
+	b.WriteString("- memories -> source = \"memory\", decode.format = \"markdown_document\"\n")
+	b.WriteString("- decisions -> source = \"decision\", decode.format = \"markdown_sections\"\n")
+	b.WriteString("- rules -> source = \"rule\", decode.format = \"markdown_sections\"\n")
+	b.WriteString("- specs -> source = \"spec\", decode.format = \"markdown_sections\"\n")
+	b.WriteString("- backlog -> source = \"backlog\", decode.format = \"markdown_sections\"")
+
+	return b.String()
+}
+
+// ValidateNoLegacySources rejects unsupported legacy [sources] tables in config files.
+func ValidateNoLegacySources(inputsDir string) error {
+	paths := []string{globalConfigPath(), "./backscroll.toml"}
+	var files []LegacySourcesFile
+
+	for _, path := range paths {
+		file, err := legacySourcesInFile(path)
+		if err != nil {
+			return err
+		}
+		if file != nil {
+			files = append(files, *file)
+		}
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	return &LegacySourcesError{Files: files, InputsDir: inputsDir}
+}
+
+func legacySourcesInFile(path string) (*LegacySourcesFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var envelope struct {
+		Sources *SourcesConfig `toml:"sources"`
+	}
+	if err := toml.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if envelope.Sources == nil {
+		return nil, nil
+	}
+
+	return &LegacySourcesFile{Path: path, Keys: legacySourcesKeys(envelope.Sources)}, nil
+}
+
+func legacySourcesKeys(sources *SourcesConfig) []string {
+	var keys []string
+	if len(sources.Backlog) > 0 {
+		keys = append(keys, "backlog")
+	}
+	if len(sources.Decisions) > 0 {
+		keys = append(keys, "decisions")
+	}
+	if len(sources.KE) > 0 {
+		keys = append(keys, "ke")
+	}
+	if len(sources.Memories) > 0 {
+		keys = append(keys, "memories")
+	}
+	if len(sources.Rules) > 0 {
+		keys = append(keys, "rules")
+	}
+	if len(sources.Specs) > 0 {
+		keys = append(keys, "specs")
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/config/legacy_sources_test.go
+++ b/internal/config/legacy_sources_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestValidateNoLegacySourcesReportsAllConfigFiles(t *testing.T) {
+	home := setupLegacySourcesTest(t)
+	globalPath := globalConfigPath()
+	writeFile(t, globalPath, `[sources]
+specs = ["docs/specs"]
+ke = ["docs/ke"]
+backlog = ["docs/backlog"]
+rules = ["docs/rules"]
+memories = ["docs/memories"]
+decisions = ["docs/decisions"]
+`)
+	writeFile(t, "backscroll.toml", `[sources]
+ke = ["local/ke"]
+`)
+	inputsDir := filepath.Join(home, ".config", "backscroll", "inputs")
+
+	err := ValidateNoLegacySources(inputsDir)
+	if err == nil {
+		t.Fatal("ValidateNoLegacySources returned nil error")
+	}
+
+	var legacyErr *LegacySourcesError
+	if !errors.As(err, &legacyErr) {
+		t.Fatalf("error type = %T, want *LegacySourcesError", err)
+	}
+	if legacyErr.InputsDir != inputsDir {
+		t.Fatalf("InputsDir = %q, want %q", legacyErr.InputsDir, inputsDir)
+	}
+
+	wantFiles := []LegacySourcesFile{
+		{Path: globalPath, Keys: []string{"backlog", "decisions", "ke", "memories", "rules", "specs"}},
+		{Path: "./backscroll.toml", Keys: []string{"ke"}},
+	}
+	if !reflect.DeepEqual(legacyErr.Files, wantFiles) {
+		t.Fatalf("Files = %#v, want %#v", legacyErr.Files, wantFiles)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{inputsDir, "markdown_document", "markdown_sections"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Error() = %q, want it to contain %q", msg, want)
+		}
+	}
+}
+
+func TestValidateNoLegacySourcesRejectsEmptyTable(t *testing.T) {
+	setupLegacySourcesTest(t)
+	writeFile(t, "backscroll.toml", `[sources]
+`)
+
+	err := ValidateNoLegacySources("/tmp/backscroll-inputs")
+	if err == nil {
+		t.Fatal("ValidateNoLegacySources returned nil error")
+	}
+
+	var legacyErr *LegacySourcesError
+	if !errors.As(err, &legacyErr) {
+		t.Fatalf("error type = %T, want *LegacySourcesError", err)
+	}
+	wantFiles := []LegacySourcesFile{{Path: "./backscroll.toml", Keys: nil}}
+	if !reflect.DeepEqual(legacyErr.Files, wantFiles) {
+		t.Fatalf("Files = %#v, want %#v", legacyErr.Files, wantFiles)
+	}
+	if !strings.Contains(err.Error(), "keys: none") {
+		t.Fatalf("Error() = %q, want it to contain %q", err.Error(), "keys: none")
+	}
+}
+
+func TestValidateNoLegacySourcesIgnoresMissingFiles(t *testing.T) {
+	setupLegacySourcesTest(t)
+
+	if err := ValidateNoLegacySources("/tmp/backscroll-inputs"); err != nil {
+		t.Fatalf("ValidateNoLegacySources returned error for missing files: %v", err)
+	}
+}
+
+func TestValidateNoLegacySourcesReportsMalformedTOML(t *testing.T) {
+	setupLegacySourcesTest(t)
+	writeFile(t, "backscroll.toml", `[sources]
+ke = ["unterminated"
+`)
+
+	err := ValidateNoLegacySources("/tmp/backscroll-inputs")
+	if err == nil {
+		t.Fatal("ValidateNoLegacySources returned nil error")
+	}
+	if !strings.Contains(err.Error(), "./backscroll.toml") {
+		t.Fatalf("Error() = %q, want it to contain malformed TOML path", err.Error())
+	}
+}
+
+func setupLegacySourcesTest(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	wd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BACKSCROLL_CONFIG_DIR", filepath.Join(home, ".config", "backscroll"))
+	t.Setenv("BACKSCROLL_DATABASE_PATH", filepath.Join(home, "backscroll.db"))
+	t.Chdir(wd)
+	return home
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}

--- a/internal/readers/markdown_reader.go
+++ b/internal/readers/markdown_reader.go
@@ -1,0 +1,123 @@
+package readers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pablontiv/backscroll/internal/input_config"
+	"github.com/pablontiv/backscroll/internal/models"
+	"github.com/pablontiv/backscroll/internal/sources"
+	"github.com/pablontiv/picokit/hashfile"
+)
+
+// MarkdownDocumentReader parses an entire Markdown file as one document record.
+type MarkdownDocumentReader struct{}
+
+// Name returns the declarative decode format for whole-document Markdown inputs.
+func (r *MarkdownDocumentReader) Name() string { return "markdown_document" }
+
+// Discover returns files matching the input definition's discovery rules.
+func (r *MarkdownDocumentReader) Discover(def input_config.InputDefinition) ([]string, error) {
+	return discoverMarkdownFiles(def)
+}
+
+// Hash returns the SHA-256 hash of the Markdown file at path.
+func (r *MarkdownDocumentReader) Hash(path string) (string, error) {
+	return hashMarkdownFile(path)
+}
+
+// Parse reads path using the existing whole-document source parser.
+func (r *MarkdownDocumentReader) Parse(path string, def input_config.InputDefinition) (models.ParsedFile, error) {
+	return parseMarkdownFile(path, def.Source, parseMarkdownDocument)
+}
+
+// MarkdownSectionsReader parses Markdown files into records split by ## sections.
+type MarkdownSectionsReader struct{}
+
+// Name returns the declarative decode format for sectioned Markdown inputs.
+func (r *MarkdownSectionsReader) Name() string { return "markdown_sections" }
+
+// Discover returns files matching the input definition's discovery rules.
+func (r *MarkdownSectionsReader) Discover(def input_config.InputDefinition) ([]string, error) {
+	return discoverMarkdownFiles(def)
+}
+
+// Hash returns the SHA-256 hash of the Markdown file at path.
+func (r *MarkdownSectionsReader) Hash(path string) (string, error) {
+	return hashMarkdownFile(path)
+}
+
+// Parse reads path using the existing sectioned source parser.
+func (r *MarkdownSectionsReader) Parse(path string, def input_config.InputDefinition) (models.ParsedFile, error) {
+	return parseMarkdownFile(path, def.Source, parseMarkdownSections)
+}
+
+func discoverMarkdownFiles(def input_config.InputDefinition) ([]string, error) {
+	paths, err := input_config.DiscoverFiles(def.Discover)
+	if err != nil {
+		return nil, fmt.Errorf("discover markdown files: %w", err)
+	}
+	return paths, nil
+}
+
+func hashMarkdownFile(path string) (string, error) {
+	hash, err := hashfile.HashFile(path)
+	if err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return hash, nil
+}
+
+type markdownParser func(path, source string) ([]sources.SourceItem, error)
+
+func parseMarkdownFile(path, source string, parser markdownParser) (models.ParsedFile, error) {
+	hash, err := hashMarkdownFile(path)
+	if err != nil {
+		return models.ParsedFile{}, err
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return models.ParsedFile{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	items, err := parser(path, source)
+	if err != nil {
+		return models.ParsedFile{}, err
+	}
+
+	messages := make([]models.Message, 0, len(items))
+	for _, item := range items {
+		messages = append(messages, models.Message{
+			Role:        "document",
+			Content:     item.Content,
+			ContentType: "text",
+			Timestamp:   info.ModTime(),
+			UUID:        "",
+		})
+	}
+
+	return models.ParsedFile{
+		Path:    path,
+		Hash:    hash,
+		Records: messages,
+		Cwd:     filepath.Dir(path),
+	}, nil
+}
+
+func parseMarkdownDocument(path, source string) ([]sources.SourceItem, error) {
+	item, err := sources.ParseDocument(path, source)
+	if err != nil {
+		return nil, fmt.Errorf("parse markdown document %s: %w", path, err)
+	}
+	return []sources.SourceItem{item}, nil
+}
+
+func parseMarkdownSections(path, source string) ([]sources.SourceItem, error) {
+	items, err := sources.ParseSectioned(path, source)
+	if err != nil {
+		return nil, fmt.Errorf("parse markdown sections %s: %w", path, err)
+	}
+	return items, nil
+}

--- a/internal/readers/markdown_reader_test.go
+++ b/internal/readers/markdown_reader_test.go
@@ -1,0 +1,187 @@
+package readers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pablontiv/backscroll/internal/input_config"
+	"github.com/pablontiv/backscroll/internal/models"
+)
+
+func TestMarkdownDocumentReaderParse(t *testing.T) {
+	path := writeMarkdownTestFile(t, "doc.md", "---\nid: ke-1\n---\n# Knowledge\n\nFull document body.\n")
+	modTime := fixedMarkdownModTime(t, path)
+
+	reader := &MarkdownDocumentReader{}
+	if got := reader.Name(); got != "markdown_document" {
+		t.Fatalf("Name() = %q, want markdown_document", got)
+	}
+
+	pf, err := reader.Parse(path, input_config.InputDefinition{Source: "ke"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if pf.Path != path {
+		t.Errorf("ParsedFile.Path = %q, want %q", pf.Path, path)
+	}
+	if pf.Hash != sha256Hex("---\nid: ke-1\n---\n# Knowledge\n\nFull document body.\n") {
+		t.Errorf("ParsedFile.Hash = %q, want SHA-256 of file content", pf.Hash)
+	}
+	if pf.Cwd != filepath.Dir(path) {
+		t.Errorf("ParsedFile.Cwd = %q, want %q", pf.Cwd, filepath.Dir(path))
+	}
+	if len(pf.Records) != 1 {
+		t.Fatalf("len(Records) = %d, want 1", len(pf.Records))
+	}
+	assertMarkdownMessage(t, pf.Records[0], "---\nid: ke-1\n---\n# Knowledge\n\nFull document body.\n", modTime)
+}
+
+func TestMarkdownSectionsReaderParse(t *testing.T) {
+	content := "# Decisions\n\n## First\nAlpha decision.\n\n## Second\nBeta decision.\n"
+	path := writeMarkdownTestFile(t, "decisions.md", content)
+	modTime := fixedMarkdownModTime(t, path)
+
+	reader := &MarkdownSectionsReader{}
+	if got := reader.Name(); got != "markdown_sections" {
+		t.Fatalf("Name() = %q, want markdown_sections", got)
+	}
+
+	pf, err := reader.Parse(path, input_config.InputDefinition{Source: "decision"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if pf.Path != path {
+		t.Errorf("ParsedFile.Path = %q, want %q", pf.Path, path)
+	}
+	if pf.Hash != sha256Hex(content) {
+		t.Errorf("ParsedFile.Hash = %q, want SHA-256 of file content", pf.Hash)
+	}
+	if pf.Cwd != filepath.Dir(path) {
+		t.Errorf("ParsedFile.Cwd = %q, want %q", pf.Cwd, filepath.Dir(path))
+	}
+	if len(pf.Records) != 2 {
+		t.Fatalf("len(Records) = %d, want 2", len(pf.Records))
+	}
+	assertMarkdownMessage(t, pf.Records[0], "## First\nAlpha decision.", modTime)
+	assertMarkdownMessage(t, pf.Records[1], "## Second\nBeta decision.", modTime)
+}
+
+func TestMarkdownSectionsReaderFallsBackToDocument(t *testing.T) {
+	path := writeMarkdownTestFile(t, "notes.md", "\nNo section heading here.\n\n")
+	modTime := fixedMarkdownModTime(t, path)
+
+	pf, err := (&MarkdownSectionsReader{}).Parse(path, input_config.InputDefinition{Source: "rule"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(pf.Records) != 1 {
+		t.Fatalf("len(Records) = %d, want 1", len(pf.Records))
+	}
+	assertMarkdownMessage(t, pf.Records[0], "No section heading here.", modTime)
+}
+
+func TestMarkdownReaderDiscoverAndHash(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "keep.md"), "keep root")
+	writeFile(t, filepath.Join(root, "skip.txt"), "skip")
+	writeFile(t, filepath.Join(root, "nested", "keep.md"), "keep nested")
+	excluded := filepath.Join(root, "nested", "excluded.md")
+	writeFile(t, excluded, "exclude")
+
+	reader := &MarkdownDocumentReader{}
+	def := input_config.InputDefinition{Discover: input_config.DiscoverConfig{
+		Roots:   []string{root},
+		Include: []string{"**/*.md"},
+		Exclude: []string{"excluded.md"},
+	}}
+
+	got, err := reader.Discover(def)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	sort.Strings(got)
+	want := []string{filepath.Join(root, "keep.md"), filepath.Join(root, "nested", "keep.md")}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discover() = %#v, want %#v", got, want)
+	}
+
+	hash, err := reader.Hash(filepath.Join(root, "nested", "keep.md"))
+	if err != nil {
+		t.Fatalf("Hash() error = %v", err)
+	}
+	if hash != sha256Hex("keep nested") {
+		t.Errorf("Hash() = %q, want SHA-256 of file content", hash)
+	}
+}
+
+func TestMarkdownReaderReportsPathErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.md")
+	_, err := (&MarkdownDocumentReader{}).Parse(missing, input_config.InputDefinition{Source: "ke"})
+	if err == nil {
+		t.Fatal("Parse() error = nil, want missing-file error")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("Parse() error = %q, want it to include %q", err.Error(), missing)
+	}
+}
+
+func assertMarkdownMessage(t *testing.T, msg models.Message, wantContent string, wantTimestamp time.Time) {
+	t.Helper()
+	if msg.Role != "document" {
+		t.Errorf("Role = %q, want document", msg.Role)
+	}
+	if msg.ContentType != "text" {
+		t.Errorf("ContentType = %q, want text", msg.ContentType)
+	}
+	if msg.UUID != "" {
+		t.Errorf("UUID = %q, want empty", msg.UUID)
+	}
+	if msg.Content != wantContent {
+		t.Errorf("Content = %q, want %q", msg.Content, wantContent)
+	}
+	if !msg.Timestamp.Equal(wantTimestamp) {
+		t.Errorf("Timestamp = %s, want %s", msg.Timestamp, wantTimestamp)
+	}
+}
+
+func writeMarkdownTestFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	writeFile(t, path, content)
+	return path
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func fixedMarkdownModTime(t *testing.T, path string) time.Time {
+	t.Helper()
+	modTime := time.Date(2026, 8, 19, 12, 34, 56, 0, time.UTC)
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("Chtimes() error = %v", err)
+	}
+	return modTime
+}
+
+func sha256Hex(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## What

- Reject legacy `[sources]` tables with a deterministic migration error before every executable command.
- Add `markdown_document` and `markdown_sections` readers to the declarative input/autosync pipeline.
- Correct the shipped decisions preset and document the supported migration mapping.
- Add hermetic CLI and end-to-end coverage for preflight behavior, source-filtered search, and idempotent autosync.

## Why

Upgrading from 0.3.x could silently stop indexing decisions and other external sources because `[sources]` remained parseable but was no longer consumed. The documented declarative replacement also failed because no Markdown reader was registered.

The other half of the report—the missing `source_metadata` column during V6—was already fixed by #34 through schema-shape-aware migration planning. This PR leaves migrations untouched and resolves the remaining configuration/ingestion regression.

Fixes #31

## How

- `config.ValidateNoLegacySources` inspects global and local config files, including empty `[sources]` tables, and returns a typed error listing files, keys, destination directory, and key-to-format mappings.
- A root Cobra `PersistentPreRunE` applies the boundary uniformly before DB, recovery, or source-file effects while preserving help/version output.
- Markdown readers reuse `internal/sources.ParseDocument` and `ParseSectioned`, SHA-256 hashing, file modtimes, and the existing reader registry/`SyncFiles` path.
- An active manifest integration test exercises discovery → parse → autosync → FTS search and proves a second unchanged run does not add rows.

Issue #33 will be classified separately after this PR; its directory/glob model already exists and this PR repairs the missing Markdown-reader path.

## Verification

- `just check` — PASS
- `just test` — PASS
- `just ci` — PASS, aggregate coverage 85.1%
- `git diff --check origin/main...HEAD` — PASS
- Independent per-task reviews — PASS
- Independent whole-branch review — READY

## Checklist

- [x] Tests pass (`just test`)
- [x] Code is clean (`just check`)
- [x] Snapshots updated if needed (not applicable)
- [x] Changes are documented if user-facing
