### PR TITLE
docs(skill): enforce indexed search discipline

### DIFF
--- a/.claude/skills/backscroll/SKILL.md
+++ b/.claude/skills/backscroll/SKILL.md
@@ -143,7 +143,7 @@ backscroll list --help
 4. **Two empty searches prove nothing.** Before concluding content is absent from the index: retry with artifact-literal terms; broaden to `--all-projects`; if a path or UUID is known, probe existing indexed rows; run one normal search without `--indexed-only` so normal search autosync can run; repeat the indexed-only probe; then collect diagnostics and report the gap.
 
 ```bash
-backscroll search "literal speaker or error" --all-projects --robot --fields minimal --max-tokens 2000
+backscroll search "literal speaker or error" --all-projects --indexed-only --robot --fields minimal --max-tokens 2000
 backscroll search "" --all-projects --indexed-only --source-path "*SESSION-UUID*" --json --fields minimal --limit 1
 backscroll search "literal speaker or error" --all-projects --robot --fields minimal --max-tokens 2000
 backscroll search "" --all-projects --indexed-only --source-path "*SESSION-UUID*" --json --fields minimal --limit 1

--- a/.claude/skills/backscroll/SKILL.md
+++ b/.claude/skills/backscroll/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backscroll
-description: "Trigger: starting work on a feature/bug with potential prior history. Explicit: prior sessions, we already did this, ya lo hicimos, what error did Y give, where did I run X, what did we decide about Z. Automatic recall for code features, testing, fixes, refactoring. Uses --project first (implicit from cwd), --all-projects if needed, --content-type tool for execution queries. Agent-grade output: --robot --fields minimal under declared token budget."
+description: "Use when starting feature, bug, test, refactor, or decision work that may have prior session history; when recalling what happened, which command failed, where something ran, or what was decided; and before considering raw coding-agent session files."
 user-invocable: true
 allowed-tools:
   - Bash
@@ -8,7 +8,7 @@ allowed-tools:
 
 # Backscroll Recipe — Recall-First for Agents
 
-Backscroll is the definitive local episodic memory for agents. Always run before starting work on a feature, bug, or test that may have history — even if you don't remember the topic. Backscroll finds what happened.
+Backscroll is the primary local episodic index for coding-agent work. Run it before starting feature, bug, test, refactor, or decision work that may have history. A hit is evidence from indexed rows. An empty result is only query/index uncertainty: it does not prove the event, file, or decision never existed.
 
 ## 1) Preflight (required)
 
@@ -17,204 +17,223 @@ command -v backscroll >/dev/null 2>&1
 backscroll status
 ```
 
-If `backscroll` is missing:
+If the binary is missing:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/pablontiv/backscroll/master/install.sh | bash
-# Alternative: copy shipped input presets after binary is in PATH
+# Optional: copy shipped input presets after the binary is in PATH.
 config_dir="${BACKSCROLL_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}}"
 mkdir -p "$config_dir/backscroll/inputs"
 cp -n inputs/claude.inputs.toml inputs/pi.inputs.toml inputs/opencode.inputs.toml inputs/decisions.inputs.toml "$config_dir/backscroll/inputs/"
 ```
 
-## 2) When to Invoke (Automatic Triggers)
+## 2) When to Invoke (automatic triggers)
 
-Invoke `/skill:backscroll` **automatically** at these points:
+Invoke `/skill:backscroll` automatically for:
 
-- **Starting a feature** ("implement X", "add Y capability") — query: feature name + goal
-- **Fixing a bug** ("fix broken Z", "handle error case") — query: error message or symptom
-- **Writing tests** ("test the validate function") — query: test subject
-- **Refactoring** ("clean up internal/X") — query: module or pattern being refactored
-- **Decision questions** ("should we use RRF or vector?", "did we decide on this?") — query: decision topic
-- **Debugging execution** ("what error did Y give?", "where did I run X?") — query: command or error, use `--content-type tool`
+- Starting a feature: query the feature name and goal.
+- Fixing a bug: query the exact error, symptom, or failing command.
+- Writing tests: query the test subject and related module.
+- Refactoring: query the module, interface, or previous pattern.
+- Decision questions: query the decision topic and alternatives.
+- Debugging execution: query command names, paths, flags, exit codes, and use `backscroll search` with `--content-type tool`.
 
-**Spanish equivalents:** "ya lo hicimos", "que hicimos con", "qué error dio", "dónde corrí", "qué decidimos".
+Spanish trigger equivalents include "ya lo hicimos", "qué hicimos con", "qué error dio", "dónde corrí", and "qué decidimos". Do not wait for explicit recall requests; missed lookup cost is rework and duplicate decisions.
 
-Do NOT wait for explicit recall requests. The cost of a missed lookup is high (rework, duplicate decisions).
+## 3) Canonical input location
 
-## 3) Canonical Input Location
+Input manifests are loaded only from:
 
-Manifests are loaded only from:
-
-```
+```text
 <config_dir>/backscroll/inputs/*.inputs.toml
 ```
 
-where `<config_dir>` is OS config directory, or `BACKSCROLL_CONFIG_DIR`.
+where `<config_dir>` is the OS config directory, or `BACKSCROLL_CONFIG_DIR`. The app config file is for database and embedding settings, not ingestion sources.
 
-`backscroll.toml` is app config only (DB/embedding), not the ingestion source.
+## 4) Agent output contract
 
-## 4) Agent Output Contract
+Use machine-readable, budgeted output:
 
-When invoked as an agent (not a human), use these flags for minimal, machine-readable output:
+- `--robot`: emits `result_N_field=value` lines.
+- `--fields minimal`: returns `source_path`, `snippet`, `score`, `role`, and `timestamp`.
+- `--fields full`: use only for a selected source-path drill.
+- `--max-tokens <budget>`: declare and enforce the output budget.
 
-**Mandatory flags:**
-- `--robot`: outputs `result_N_field=value` format (no text decoration)
-- `--fields minimal`: JSON fields only (`source_path`, `snippet`, `score`, `role`, `timestamp`)
-- `--max-tokens <budget>`: enforce output size limit; agent declares budget (e.g., 2000 tokens for a lookup)
+Canonical retrieval:
 
-**Recipe:**
 ```bash
-# Project-scoped query first
-backscroll search "QUERY" --project <cwd-or-inferred> --robot --fields minimal --max-tokens 2000
+# First query: cwd-inferred project scope.
+backscroll search "QUERY" --robot --fields minimal --max-tokens 2000
 
-# If no results, expand to all projects
-if [ $? -ne 0 ] || [ -z "$result" ]; then
-  backscroll search "QUERY" --all-projects --robot --fields minimal --max-tokens 2000
-fi
+# Second query: broaden scope explicitly if the first result set is empty or irrelevant.
+backscroll search "QUERY" --all-projects --robot --fields minimal --max-tokens 2000
 
-# For execution-shaped queries (commands, errors, paths), use --content-type tool
+# Execution-shaped queries: commands, flags, errors, paths.
 backscroll search "command or error" --all-projects --content-type tool --robot --fields minimal --max-tokens 1500
 ```
 
-**Token budget guidance:**
-- Lookup for start-of-feature decision: 1500–2000 tokens.
-- Multi-project cross-reference: 2000–3000 tokens.
-- Tool/error investigation: 1000–1500 tokens (trigram tokenizer, precise results).
-- Default ceiling: `--max-tokens 2000` unless the agent explicitly declares a higher budget.
+If an explicit project is needed, use a semantic project ID, not a filesystem path:
 
-**Token accounting:** The formatter respects `--max-tokens` and truncates output. If the search completes but is truncated, the output ends with an indicator; the agent should interpret partial results as "index knows the topic exists" and may refine the query.
+```bash
+backscroll search "split FTS index" --project backscroll --robot --fields minimal --max-tokens 2000
+```
 
-## 5) Query Patterns by Use Case
+Token budget guidance:
 
-### Decision Recovery
+- Feature/bug/decision recall: 1500–2000 tokens.
+- Cross-project lookup: 2000–3000 tokens.
+- Tool/error investigation: 1000–1500 tokens; use literal strings of at least three characters.
+- Default ceiling: `--max-tokens 2000` unless a higher budget is justified.
+
+If output is truncated, treat it as evidence that more indexed data exists. Refine the query, selected source, or budget instead of abandoning the index.
+
+## 5) Query patterns by use case
+
+### Decision recovery
+
 ```bash
 backscroll search "should we use RRF or vector" --all-projects --robot --fields minimal --max-tokens 2000
 backscroll search "migration v7 reasoning index" --all-projects --robot --fields minimal --max-tokens 2000
 ```
 
-### Error Investigation
+### Error investigation
+
 ```bash
 backscroll search "SQLITE_BUSY database is locked" --all-projects --content-type tool --robot --fields minimal --max-tokens 1500
 backscroll search "exit code 1" --all-projects --content-type tool --robot --fields minimal --max-tokens 1500
 ```
 
-### Feature Work Recovery
+### Feature work recovery
+
 ```bash
-backscroll search "split FTS index" --project <cwd> --robot --fields minimal --max-tokens 2000
+backscroll search "split FTS index" --robot --fields minimal --max-tokens 2000
 backscroll search "backscroll search --robot" --all-projects --content-type tool --robot --fields minimal --max-tokens 1500
 ```
 
-### Code Pattern Lookup
+### Code pattern lookup
+
 ```bash
-backscroll search "SearchEngine interface" --project <cwd> --robot --fields minimal --max-tokens 1500
+backscroll search "SearchEngine interface" --robot --fields minimal --max-tokens 1500
 ```
 
-### Cross-Project Execution
+### Cross-project execution
+
 ```bash
 backscroll search "go test" --all-projects --content-type tool --robot --fields minimal --max-tokens 1500
 ```
 
-## 6) Degradation & Error Handling
+## Search discipline (hard rules)
 
-**Index is stale or locked:**
-If `backscroll status` shows zero indexed files or if auto-sync fails:
+1. **Drill the top hit.** If a top-ranked result contains relevant decision keywords, inspect indexed rows from that returned path before dismissing it by age or hunting another session.
+
 ```bash
-backscroll search ... 2>&1 | grep -E "warning|suggestions"
+SOURCE_PATH="<result_N_source_path>"
+backscroll search "" --all-projects --indexed-only --source-path "$SOURCE_PATH" --robot --fields full --max-tokens 4000
 ```
 
-The CLI prints actionable hints to stderr:
-- `--all-projects`: expand search scope.
-- `--content-type tool`: try tool-only search (better for commands/errors).
-- `backscroll status`: confirm index size and last-indexed time.
+2. **Use the artifact's vocabulary.** For transcripts, logs, reports, and pasted artifacts, query literal speaker names, boilerplate, IDs, exact errors, paths, and the artifact language. A translated or paraphrased query is secondary evidence only.
 
-Do NOT retry the same query. Act on the hints or report stale index.
+3. **A failed invocation is a syntax problem first.** For unknown flags, missing arguments, warnings, or path/session resolution errors, check current help, correct the command, and retry once. Never cite one malformed call as tool failure.
 
-**No results (empty result set):**
-The agent receives zero rows. Interpret as "query term not in index" — do NOT infer "topic doesn't exist". Refine the query (shorter terms, broader project scope, `--all-projects`) and retry once. If still zero, escalate to manual human recall.
-
-**Output truncated by --max-tokens:**
-If the output ends abruptly or shows a truncation indicator, the index has more data but the budget was exhausted. Refine the query (narrower date range, `--source session` to exclude plans) or increase the budget.
-
-## 7) Troubleshooting
-
-**No command `backscroll`:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pablontiv/backscroll/master/install.sh | bash
+backscroll search --help
+backscroll list --help
 ```
 
-**Database locked (SQLITE_BUSY):**
+4. **Two empty searches prove nothing.** Before concluding content is absent from the index: retry with artifact-literal terms; broaden to `--all-projects`; if a path or UUID is known, probe existing indexed rows; run one normal search without `--indexed-only` so normal search autosync can run; repeat the indexed-only probe; then collect diagnostics and report the gap.
+
+```bash
+backscroll search "literal speaker or error" --all-projects --robot --fields minimal --max-tokens 2000
+backscroll search "" --all-projects --indexed-only --source-path "*SESSION-UUID*" --json --fields minimal --limit 1
+backscroll search "literal speaker or error" --all-projects --robot --fields minimal --max-tokens 2000
+backscroll search "" --all-projects --indexed-only --source-path "*SESSION-UUID*" --json --fields minimal --limit 1
+backscroll status
+backscroll validate --indexed-only
+```
+
+Report the source path or UUID, literal probes, scopes used, and full diagnostic output as an indexing gap when the probe remains absent.
+
+5. **Raw-file boundary.** `cat`, `jq`, Python, or direct `backscroll read` is not a normal retrieval fallback. Do not use raw JSONL parsing, directory listings for session hunting, or direct file reads unless the user explicitly authorizes indexing-bug diagnosis after you report the gap and the indexed commands attempted.
+
+## 6) Degradation and troubleshooting
+
+**Index stale, locked, or unhealthy:** preserve full command output. Do not pipe diagnostics through filters that hide warnings or suggestions.
+
+```bash
+backscroll status
+backscroll validate --indexed-only
+```
+
+If a search warns about scope, content type, or compatibility, follow the hint and rerun a corrected current command once.
+
+**No results:** follow the hard rules: literal artifact vocabulary, all-projects scope, source-path/UUID probe, one normal search for autosync, repeated indexed-only probe, then status and validate. Report uncertainty; do not convert empty rows into proof of absence.
+
+**Tool-query tokenizer limits:** the tool index uses a trigram tokenizer. Prefer exact flags, paths, command names, and error fragments of at least three characters, for example `"--content-type tool"`, `"go test"`, or `"BUSY"`.
+
+**Output truncated by budget:** narrow the query or selected source path, or increase the declared budget. Truncation means the index had more data than fit.
+
+**Database locked:** wait a few seconds and retry. If persistent, identify the locking process before further remediation.
+
 ```bash
 backscroll status
 ```
-Wait a few seconds and retry. If persistent, the database file is locked by another process (another backscroll invocation, or stale file handle). Check `lsof /path/to/.backscroll.db`.
 
-**Zero results on tool query with ≥3 character term:**
-The `tool_fts` index uses trigram tokenizer; some pattern may not match. Try:
-- Exact flag/path: `"--content-type tool"` (has 15+ chars, should match).
-- Command name: `"go test"` (should match, but "go" alone may not).
-- Error fragment: `"BUSY"` (should match, but "go" alone will not).
+**Explicit index or FTS corruption:** reserve rebuild for corruption repair after diagnostics indicate an index problem; it is not missing-input discovery.
 
-**Still zero results:**
 ```bash
-backscroll status  # Confirm index is populated
-backscroll validate --indexed-only  # Check for orphan rows
-backscroll rebuild  # Full reindex if suspect corruption
+backscroll rebuild
 ```
 
-## 8) Token Budget Allocation for Agents
+## 7) Token budget allocation for agents
 
-When an agent invokes multiple backscroll lookups in a single session:
+| Use case | Budget | Notes |
+|---|---:|---|
+| Pre-work feature/bug recall | 2000 | First lookup in the session. |
+| Refinement | 1000–1500 | Narrow query after first pass. |
+| Tool/error investigation | 1000–1500 | Exact command, flag, path, or error. |
+| Cross-project reference | 2000 | Wider scope. |
+| Decision context | 1500–2000 | Decision prose can be longer. |
 
-| Use Case | Budget | Notes |
-|----------|--------|-------|
-| Pre-work feature/bug recall | 2000 | First lookup in the session; larger budget justified. |
-| Refinement/clarification | 1000–1500 | Narrow query after first pass. |
-| Tool error investigation | 1000–1500 | Exact command/error; trigram tokenizer is precise. |
-| Cross-project reference | 2000 | Wider scope, larger budget acceptable. |
-| Decision context | 1500–2000 | Decision topics tend to have longer prose matches. |
+Agents should usually spend about 5000 tokens across three or four lookups. Refine before increasing budget.
 
-**Total per session**: Agents should allocate ~5000 tokens for episodic recall (3–4 lookups). If a single lookup is insufficient, refine the query rather than increase the budget.
-
-Declare the budget upfront:
 ```bash
 backscroll search "query" --all-projects --robot --fields minimal --max-tokens 2000
 ```
 
-The CLI will truncate output if needed; the agent reads truncation as "got what fit".
-
 ## References
 
-- **CLI documentation**: `backscroll search --help`, `backscroll list --help`, `backscroll read --help`
-- **v1.4.0+ improvements**: Split FTS index (Slice 1) — `tool_fts` with trigram tokenizer for exact command/error matching; `messages_fts` with porter tokenizer for prose. Switched by `--content-type`.
-- **Deployable version check**: `backscroll version` or `backscroll status` shows deployed build.
-- **Diagnostic skill**: `backscroll-doctor` self-audits the index for bugs, gaps, enhancements.
+- CLI help: `backscroll search --help`, `backscroll list --help`, `backscroll patterns --help`, `backscroll annotate --help`.
+- Deployable version check: `backscroll --version`; `backscroll status` also shows deployed build and index state.
+- v1.4.0+ search behavior: split FTS indexes; `tool_fts` uses trigram tokenization for exact command/error matching, while `messages_fts` uses porter tokenization for prose. Select with `--content-type`.
+- Diagnostic skill: `backscroll-doctor` audits index bugs, gaps, and enhancement candidates.
 
-## Pattern Discovery (v2.7+): census, not retrieval
+## Pattern discovery: census, not retrieval
 
-`search` answers "find what I can already name". For DISCOVERY — "what
-recurs that nobody named?" — use the census commands instead; asking
-BM25 for patterns only yields anecdotes.
+`backscroll search` answers “find what I can already name.” For discovery — “what recurs that nobody named?” — use census commands. BM25 pattern queries usually yield anecdotes, not counts.
 
 | Question | Command |
 |---|---|
-| What errors recur? | `patterns --kind templates --min-support 3` |
-| What breaks, and is it growing? | `patterns --kind failures [--trend]` |
-| Where did the user correct me/us? | `patterns --kind corrections --min-confidence 0.6` |
-| What workflows repeat? | `patterns --kind sequences --min-support 20 --min-length 3` |
-| What runs most (per project/tag)? | `patterns --kind commands --project X` |
+| What errors recur? | `backscroll patterns --kind templates --min-support 3` |
+| What breaks, and is it growing? | `backscroll patterns --kind failures --trend` |
+| Where did the user correct me/us? | `backscroll patterns --kind corrections --min-confidence 0.6` |
+| What workflows repeat? | `backscroll patterns --kind sequences --min-support 20 --min-length 3` |
+| What runs most for a project? | `backscroll patterns --kind commands --project backscroll` |
 
-Agent-grade: add `--robot --indexed-only --all-projects`. Interpret the
-COMPLETE table returned — the census already did the counting; the
-agent's job is judgment, not sampling.
+Agent-grade census output:
+
+```bash
+backscroll patterns --kind corrections --pending --batch 50 --robot
+backscroll patterns --kind commands --all-projects --indexed-only --robot
+```
+
+Interpret the complete table returned. The census did the counting; the agent's job is judgment, not sampling.
 
 ### Classification loop (resumable by construction)
 
 ```bash
-patterns --kind corrections --pending --batch 50 --robot   # fetch unlabeled
-annotate --uuid <u> --kind correction --label "<free-form>" # write back
-# re-run fetch: labeled candidates vanish (LEFT JOIN) — no loop state needed
+backscroll patterns --kind corrections --pending --batch 50 --robot
+backscroll annotate --uuid <u> --kind correction --label "<free-form>"
+# Re-run fetch: labeled candidates vanish, so no loop state is needed.
 ```
 
-Full doc: `docs/patterns.md`. Calibration gate before trusting
-confidences: `docs/eval/corrections-calibration.md`.
+Full doc: `docs/patterns.md`. Calibration gate before trusting confidences: `docs/eval/corrections-calibration.md`.

--- a/.claude/skills/backscroll/ref-context-mode.md
+++ b/.claude/skills/backscroll/ref-context-mode.md
@@ -5,9 +5,9 @@ Use this only for `/skill:backscroll --context`. Produce a recovery brief with: 
 ## Required Backscroll Retrieval
 
 ```bash
-backscroll validate
-backscroll status
-backscroll list --input claude --limit 10 --all-projects
+backscroll validate --indexed-only
+backscroll status --indexed-only
+backscroll list --limit 10 --all-projects --json
 ```
 
 If the user supplied a query, search for it. Otherwise use the directory name plus context terms:
@@ -20,8 +20,10 @@ backscroll search "$PROJECT_SLUG context decisions handoff blockers" --all-proje
 If this returns no useful results, run one broader session search:
 
 ```bash
-backscroll search "$PROJECT_SLUG" --input claude --all-projects --max-tokens 4000
+backscroll search "$PROJECT_SLUG" --source session --all-projects --max-tokens 4000
 ```
+
+For empty results or suspected gaps, follow the main skill's search discipline rather than raw-file fallback.
 
 ## Optional Rootline State
 

--- a/cmd/backscroll/skill_contract_test.go
+++ b/cmd/backscroll/skill_contract_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBackscrollSkillContractAcceptsCurrentCLIForms(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	content := strings.Join([]string{
+		"backscroll --version",
+		"backscroll --help",
+		"backscroll search --help",
+		"command -v backscroll >/dev/null",
+		"backscroll search \"needle\" --all-projects --source-path \"*uuid*\" --indexed-only --robot --fields full --max-tokens 4000",
+		"backscroll list --all-projects --limit 10 --json",
+		"backscroll patterns --kind corrections --pending --batch 50 --robot",
+		"backscroll annotate --uuid u --kind correction --label false-positive",
+	}, "\n")
+
+	violations := validateSkillMarkdown(root, "synthetic-valid.md", content)
+	if len(violations) > 0 {
+		t.Fatalf("expected current CLI forms to pass, got violations:\n%s", formatSkillContractViolations(violations))
+	}
+}
+
+func TestBackscrollSkillContractRejectsUnknownCommands(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	content := strings.Join([]string{
+		"backscroll sync",
+		"backscroll events query id",
+		"backscroll version",
+	}, "\n")
+
+	violations := validateSkillMarkdown(root, "synthetic-unknown-commands.md", content)
+	assertSkillContractViolations(t, violations,
+		"synthetic-unknown-commands.md:1: unknown backscroll command \"sync\"",
+		"synthetic-unknown-commands.md:2: unknown backscroll command \"events\"",
+		"synthetic-unknown-commands.md:3: unknown backscroll command \"version\"",
+	)
+}
+
+func TestBackscrollSkillContractRejectsUnknownFlags(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	content := "backscroll search term --input claude"
+
+	violations := validateSkillMarkdown(root, "synthetic-unknown-flags.md", content)
+	assertSkillContractViolations(t, violations,
+		"synthetic-unknown-flags.md:1: unknown flag --input for backscroll search",
+	)
+}
+
+func TestBackscrollSkillContractRejectsBareSubcommands(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	content := strings.Join([]string{
+		"patterns --kind templates",
+		"`annotate --uuid u --kind correction --label x`",
+	}, "\n")
+
+	violations := validateSkillMarkdown(root, "synthetic-bare-subcommands.md", content)
+	assertSkillContractViolations(t, violations,
+		"synthetic-bare-subcommands.md:1: bare backscroll subcommand \"patterns\"; prefix with backscroll",
+		"synthetic-bare-subcommands.md:2: bare backscroll subcommand \"annotate\"; prefix with backscroll",
+	)
+}
+
+func TestBackscrollSkillContractRejectsStaleAutoupdateOptOut(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	content := "BACKSCROLL_AUTOUPDATE_DISABLE=1 backscroll status"
+
+	violations := validateSkillMarkdown(root, "synthetic-stale-autoupdate.md", content)
+	assertSkillContractViolations(t, violations,
+		"synthetic-stale-autoupdate.md:1: stale autoupdate opt-out BACKSCROLL_AUTOUPDATE_DISABLE is not supported",
+	)
+}
+
+func assertSkillContractViolations(t *testing.T, got []skillContractViolation, want ...string) {
+	t.Helper()
+	gotText := strings.TrimSpace(formatSkillContractViolations(got))
+	wantText := strings.Join(want, "\n")
+	if gotText != wantText {
+		t.Fatalf("unexpected violations:\nwant:\n%s\n\ngot:\n%s", wantText, gotText)
+	}
+}
+
+type skillContractViolation struct {
+	path    string
+	line    int
+	message string
+}
+
+func validateSkillMarkdown(root *cobra.Command, path, content string) []skillContractViolation {
+	registeredSubcommands := backscrollSubcommands(root)
+	var violations []skillContractViolation
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		lineNumber := i + 1
+		if strings.Contains(line, "BACKSCROLL_AUTOUPDATE_DISABLE") {
+			violations = append(violations, skillContractViolation{
+				path:    path,
+				line:    lineNumber,
+				message: "stale autoupdate opt-out BACKSCROLL_AUTOUPDATE_DISABLE is not supported",
+			})
+		}
+
+		// This is intentionally not a general shell parser. The skill uses simple
+		// one-command snippets, so we tokenize enough Markdown code/prose to catch
+		// documented `backscroll ...` invocations without executing anything.
+		violations = append(violations, validateBackscrollInvocations(root, path, lineNumber, line)...)
+		violations = append(violations, validateBareSubcommand(path, lineNumber, line, registeredSubcommands)...)
+		for _, span := range inlineCodeSpans(line) {
+			violations = append(violations, validateBackscrollInvocations(root, path, lineNumber, span)...)
+			violations = append(violations, validateBareSubcommand(path, lineNumber, span, registeredSubcommands)...)
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].path != violations[j].path {
+			return violations[i].path < violations[j].path
+		}
+		if violations[i].line != violations[j].line {
+			return violations[i].line < violations[j].line
+		}
+		return violations[i].message < violations[j].message
+	})
+	return uniqueSkillContractViolations(violations)
+}
+
+func validateBackscrollInvocations(root *cobra.Command, path string, lineNumber int, text string) []skillContractViolation {
+	tokens := shellishFields(text)
+	var violations []skillContractViolation
+	for i, token := range tokens {
+		if token != "backscroll" || isURLToken(token) || isCommandVBackscroll(tokens, i) {
+			continue
+		}
+
+		args := invocationArgs(tokens[i+1:])
+		cmd := root
+		cmdName := root.Name()
+		flagArgs := args
+		if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+			child := findSubcommand(root, args[0])
+			if child == nil {
+				violations = append(violations, skillContractViolation{
+					path:    path,
+					line:    lineNumber,
+					message: fmt.Sprintf("unknown backscroll command %q", args[0]),
+				})
+				continue
+			}
+			cmd = child
+			cmdName = root.Name() + " " + child.Name()
+			flagArgs = args[1:]
+		}
+
+		for _, flagName := range longFlags(flagArgs) {
+			if isSupportedFlag(cmd, flagName) {
+				continue
+			}
+			violations = append(violations, skillContractViolation{
+				path:    path,
+				line:    lineNumber,
+				message: fmt.Sprintf("unknown flag --%s for %s", flagName, cmdName),
+			})
+		}
+	}
+	return violations
+}
+
+func validateBareSubcommand(path string, lineNumber int, text string, registeredSubcommands map[string]struct{}) []skillContractViolation {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" || strings.HasPrefix(trimmed, "backscroll ") || strings.HasPrefix(trimmed, "command -v backscroll") {
+		return nil
+	}
+	trimmed = strings.TrimPrefix(trimmed, "$ ")
+	trimmed = strings.TrimPrefix(trimmed, "> ")
+	tokens := shellishFields(trimmed)
+	if len(tokens) == 0 {
+		return nil
+	}
+	command := tokens[0]
+	if _, ok := registeredSubcommands[command]; !ok {
+		return nil
+	}
+	return []skillContractViolation{{
+		path:    path,
+		line:    lineNumber,
+		message: fmt.Sprintf("bare backscroll subcommand %q; prefix with backscroll", command),
+	}}
+}
+
+func backscrollSubcommands(root *cobra.Command) map[string]struct{} {
+	commands := make(map[string]struct{})
+	for _, cmd := range root.Commands() {
+		commands[cmd.Name()] = struct{}{}
+	}
+	return commands
+}
+
+func findSubcommand(root *cobra.Command, name string) *cobra.Command {
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == name || cmd.HasAlias(name) {
+			return cmd
+		}
+	}
+	return nil
+}
+
+func invocationArgs(tokens []string) []string {
+	for i, token := range tokens {
+		if isShellTerminator(token) {
+			return tokens[:i]
+		}
+	}
+	return tokens
+}
+
+func isShellTerminator(token string) bool {
+	switch token {
+	case "|", "||", "&&", ";", "#":
+		return true
+	default:
+		return strings.HasPrefix(token, "#")
+	}
+}
+
+func longFlags(tokens []string) []string {
+	var flags []string
+	for _, token := range tokens {
+		if !strings.HasPrefix(token, "--") || token == "--" {
+			continue
+		}
+		name := strings.TrimPrefix(token, "--")
+		if before, _, ok := strings.Cut(name, "="); ok {
+			name = before
+		}
+		name = strings.TrimRight(name, ",.;:)]}")
+		if name != "" {
+			flags = append(flags, name)
+		}
+	}
+	return flags
+}
+
+func isSupportedFlag(cmd *cobra.Command, name string) bool {
+	if name == "help" {
+		return true
+	}
+	if cmd.Parent() == nil && name == "version" {
+		return true
+	}
+	return cmd.Flags().Lookup(name) != nil ||
+		cmd.InheritedFlags().Lookup(name) != nil ||
+		cmd.PersistentFlags().Lookup(name) != nil
+}
+
+func isCommandVBackscroll(tokens []string, index int) bool {
+	return index >= 2 && tokens[index-2] == "command" && tokens[index-1] == "-v"
+}
+
+func isURLToken(token string) bool {
+	return strings.Contains(token, "://")
+}
+
+func inlineCodeSpans(line string) []string {
+	if strings.HasPrefix(strings.TrimSpace(line), "```") {
+		return nil
+	}
+	var spans []string
+	for {
+		start := strings.Index(line, "`")
+		if start == -1 {
+			return spans
+		}
+		line = line[start+1:]
+		end := strings.Index(line, "`")
+		if end == -1 {
+			return spans
+		}
+		spans = append(spans, line[:end])
+		line = line[end+1:]
+	}
+}
+
+func shellishFields(text string) []string {
+	var fields []string
+	var current strings.Builder
+	var quote rune
+	for _, r := range text {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+		case r == '\'' || r == '"':
+			quote = r
+		case r == '\t' || r == ' ':
+			if current.Len() > 0 {
+				fields = append(fields, cleanShellToken(current.String()))
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		fields = append(fields, cleanShellToken(current.String()))
+	}
+	return fields
+}
+
+func cleanShellToken(token string) string {
+	return strings.Trim(token, "`.,;:()[]{}")
+}
+
+func uniqueSkillContractViolations(violations []skillContractViolation) []skillContractViolation {
+	if len(violations) < 2 {
+		return violations
+	}
+	unique := violations[:1]
+	for _, violation := range violations[1:] {
+		last := unique[len(unique)-1]
+		if violation == last {
+			continue
+		}
+		unique = append(unique, violation)
+	}
+	return unique
+}
+
+func formatSkillContractViolations(violations []skillContractViolation) string {
+	var out strings.Builder
+	for _, violation := range violations {
+		_, _ = fmt.Fprintf(&out, "%s:%d: %s\n", violation.path, violation.line, violation.message)
+	}
+	return out.String()
+}

--- a/cmd/backscroll/skill_contract_test.go
+++ b/cmd/backscroll/skill_contract_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -79,6 +82,50 @@ func TestBackscrollSkillContractRejectsStaleAutoupdateOptOut(t *testing.T) {
 	)
 }
 
+func TestBackscrollSkillCommandsMatchCLI(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	path, content := readTrackedSkillMarkdown(t, ".claude/skills/backscroll/SKILL.md")
+
+	violations := validateSkillMarkdown(root, path, content)
+	if len(violations) > 0 {
+		t.Fatalf("documented backscroll commands must match the Cobra CLI:\n%s", formatSkillContractViolations(violations))
+	}
+}
+
+func TestBackscrollSkillContainsSearchDiscipline(t *testing.T) {
+	_, content := readTrackedSkillMarkdown(t, ".claude/skills/backscroll/SKILL.md")
+
+	anchors := []string{
+		"Search discipline (hard rules)",
+		"Drill the top hit",
+		"artifact's vocabulary",
+		"failed invocation is a syntax problem",
+		"Two empty searches prove nothing",
+		"Raw-file boundary",
+		"--source-path",
+		"--indexed-only",
+		"backscroll validate --indexed-only",
+	}
+	for _, anchor := range anchors {
+		if !strings.Contains(content, anchor) {
+			t.Errorf("missing search-discipline anchor %q", anchor)
+		}
+	}
+
+	rawBoundaryAnchors := []string{
+		"cat",
+		"jq",
+		"Python",
+		"direct `backscroll read`",
+		"not a normal retrieval fallback",
+	}
+	for _, anchor := range rawBoundaryAnchors {
+		if !strings.Contains(content, anchor) {
+			t.Errorf("missing raw-file boundary anchor %q", anchor)
+		}
+	}
+}
+
 func assertSkillContractViolations(t *testing.T, got []skillContractViolation, want ...string) {
 	t.Helper()
 	gotText := strings.TrimSpace(formatSkillContractViolations(got))
@@ -86,6 +133,20 @@ func assertSkillContractViolations(t *testing.T, got []skillContractViolation, w
 	if gotText != wantText {
 		t.Fatalf("unexpected violations:\nwant:\n%s\n\ngot:\n%s", wantText, gotText)
 	}
+}
+
+func readTrackedSkillMarkdown(t *testing.T, relativePath string) (string, string) {
+	t.Helper()
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("resolve test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	content, err := os.ReadFile(filepath.Join(repoRoot, relativePath))
+	if err != nil {
+		t.Fatalf("read %s: %v", relativePath, err)
+	}
+	return relativePath, string(content)
 }
 
 type skillContractViolation struct {
@@ -135,7 +196,7 @@ func validateBackscrollInvocations(root *cobra.Command, path string, lineNumber 
 	tokens := shellishFields(text)
 	var violations []skillContractViolation
 	for i, token := range tokens {
-		if token != "backscroll" || isURLToken(token) || isCommandVBackscroll(tokens, i) {
+		if token != "backscroll" || isURLToken(token) || isCommandVBackscroll(tokens, i) || !isInvocationStart(tokens, i) {
 			continue
 		}
 
@@ -227,6 +288,36 @@ func isShellTerminator(token string) bool {
 	default:
 		return strings.HasPrefix(token, "#")
 	}
+}
+
+func isInvocationStart(tokens []string, index int) bool {
+	if index == 0 {
+		return true
+	}
+	previous := tokens[index-1]
+	if previous == "$" || previous == ">" || isShellTerminator(previous) {
+		return true
+	}
+	for _, token := range tokens[:index] {
+		if !isShellAssignment(token) {
+			return false
+		}
+	}
+	return true
+}
+
+func isShellAssignment(token string) bool {
+	name, _, ok := strings.Cut(token, "=")
+	if !ok || name == "" || strings.HasPrefix(name, "-") {
+		return false
+	}
+	for _, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func longFlags(tokens []string) []string {

--- a/cmd/backscroll/skill_contract_test.go
+++ b/cmd/backscroll/skill_contract_test.go
@@ -126,6 +126,64 @@ func TestBackscrollSkillContainsSearchDiscipline(t *testing.T) {
 	}
 }
 
+func TestBackscrollContextModeCommandsMatchCLI(t *testing.T) {
+	root := buildRootCmd(io.Discard, io.Discard)
+	path, content := readTrackedSkillMarkdown(t, ".claude/skills/backscroll/ref-context-mode.md")
+
+	violations := validateSkillMarkdown(root, path, content)
+	if len(violations) > 0 {
+		t.Fatalf("documented context-mode backscroll commands must match the Cobra CLI:\n%s", formatSkillContractViolations(violations))
+	}
+
+	if strings.Contains(content, "--input") {
+		t.Error("context mode must not document removed --input flags")
+	}
+	assertSourceSessionOnlyOnSearch(t, content)
+	assertExactContextOutputSections(t, content)
+	if !strings.Contains(content, "main skill's search discipline") && !strings.Contains(content, "indexed boundary") {
+		t.Error("context mode must point to the main search discipline or preserve the indexed boundary")
+	}
+}
+
+func assertSourceSessionOnlyOnSearch(t *testing.T, content string) {
+	t.Helper()
+	found := false
+	for _, line := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.Contains(trimmed, "--source session") {
+			continue
+		}
+		found = true
+		if !strings.HasPrefix(trimmed, "backscroll search ") {
+			t.Errorf("--source session must be used only on backscroll search, got %q", trimmed)
+		}
+	}
+	if !found {
+		t.Error("context mode must include a session-only search with --source session")
+	}
+}
+
+func assertExactContextOutputSections(t *testing.T, content string) {
+	t.Helper()
+	want := []string{
+		"1. `Backscroll`: relevant sessions/documents and paths.",
+		"2. `Rootline`: live records found, or `not available` with the skipped gate.",
+		"3. `Gaps`: missing manifests, empty index, absent session-state, or schema/validation errors.",
+	}
+	lastIndex := -1
+	for _, section := range want {
+		if strings.Count(content, section) != 1 {
+			t.Errorf("context mode must require exactly one output section line %q", section)
+			continue
+		}
+		index := strings.Index(content, section)
+		if index <= lastIndex {
+			t.Errorf("context output section %q is out of order", section)
+		}
+		lastIndex = index
+	}
+}
+
 func assertSkillContractViolations(t *testing.T, got []skillContractViolation, want ...string) {
 	t.Helper()
 	gotText := strings.TrimSpace(formatSkillContractViolations(got))

--- a/docs/superpowers/plans/2026-08-19-search-discipline-skill.md
+++ b/docs/superpowers/plans/2026-08-19-search-discipline-skill.md
@@ -1,0 +1,474 @@
+# Backscroll Search-Discipline Skill Implementation Plan
+
+> **For implementer:** REQUIRED SUB-SKILLS: Use `writing-skills` and `test-driven-development`. Execute in `/Users/Shared/harness/.worktrees/backscroll-issue-30` on branch `docs/issue-30-search-discipline`. No skill guidance may be edited before baseline pressure evidence and a failing automated test exist. Commit each task independently and obtain independent review before the next task.
+
+**Goal:** Make Backscroll's tracked agent skill resist the observed raw-JSONL fallback failures, reconcile every tracked recipe with the current CLI, and fail CI when documented commands or flags drift from Cobra.
+
+**Architecture:** Keep `.claude/skills/backscroll` as the versioned source. A test-only contract parser in `cmd/backscroll` reads Markdown command forms, resolves them against `buildRootCmd`, validates long flags, rejects unprefixed subcommands, and protects behavioral anchors. Skill edits then use only indexed v3 retrieval (`search --source-path`, autosync through normal search, diagnostics through status/validate), with pressure-scenario verification before and after.
+
+**Tech Stack:** Markdown skill files, Go stdlib testing/regexp/runtime, Cobra command tree, repository hooks unchanged.
+
+**Design:** `docs/superpowers/specs/2026-08-19-search-discipline-skill-design.md`
+
+---
+
+## Global execution rules
+
+- Follow the `writing-skills` iron law: capture baseline agent behavior before editing the skill, then rerun equivalent pressure scenarios against the edited skill.
+- Follow red-green-refactor for the automated contract.
+- Do not edit installed copies under `~/.claude` or `~/.agents`; pre-push/post-merge distribution remains unchanged.
+- Do not add or document removed CLI surfaces (`sync`, `events`, `sessions`, `--input`).
+- Do not modify Cobra commands, search/storage behavior, migrations, manifests, or hooks.
+- Keep each issue in its own PR; this branch contains only #30 design, plan, skill docs, and contract tests.
+- Pressure-test agents are read-only. They must not edit files or inspect the target skill during the baseline run.
+
+## Task 1: Capture baseline failures and build the static contract validator
+
+**Files:**
+- Create: `cmd/backscroll/skill_contract_test.go`
+- Reference: `cmd/backscroll/main.go`
+- Reference: `.claude/skills/backscroll/SKILL.md`
+- Reference: `.claude/skills/backscroll/ref-context-mode.md`
+
+### Step 1: Run baseline pressure scenarios before editing skill guidance
+
+Dispatch two independent read-only subagents without directing them to read the target skill.
+
+**Scenario A — top-hit/time pressure:**
+
+```text
+You need an answer quickly. Backscroll search returned an older session at ranks 1–3 whose snippet contains the exact decision keywords. A newer-looking raw JSONL exists on disk. State the next commands/actions. You have five minutes and may use shell/Python if useful.
+```
+
+Record whether the agent:
+
+- drills the ranked source path through indexed search;
+- dismisses it based on age;
+- hunts files or parses JSONL.
+
+**Scenario B — malformed call + translated query + gap:**
+
+```text
+Two paraphrased searches in Spanish returned nothing for an English meeting transcript. One attempted Backscroll command returned a syntax/session warning. A known JSONL path from the date is absent from a recent listing. Explain how you recover and when you parse the raw file.
+```
+
+Record whether the agent:
+
+- checks current command help;
+- tries artifact-literal English terms;
+- probes a known indexed source path;
+- invents removed commands;
+- jumps to raw parsing without reporting a gap.
+
+At least one observed violation or ambiguity is expected from the documented issue. If both agents fully comply, add a third combined-pressure scenario rather than weakening the requirement. Keep the evidence in the task report; do not add generated transcripts to the repository.
+
+### Step 2: Write failing synthetic contract tests
+
+Create `cmd/backscroll/skill_contract_test.go` with tests named:
+
+```go
+func TestBackscrollSkillContractAcceptsCurrentCLIForms(t *testing.T)
+func TestBackscrollSkillContractRejectsUnknownCommands(t *testing.T)
+func TestBackscrollSkillContractRejectsUnknownFlags(t *testing.T)
+func TestBackscrollSkillContractRejectsBareSubcommands(t *testing.T)
+func TestBackscrollSkillContractRejectsStaleAutoupdateOptOut(t *testing.T)
+```
+
+Synthetic valid examples must include:
+
+```text
+backscroll --version
+backscroll search "needle" --all-projects --source-path "*uuid*" --indexed-only --robot --fields full --max-tokens 4000
+backscroll list --all-projects --limit 10 --json
+backscroll patterns --kind corrections --pending --batch 50 --robot
+backscroll annotate --uuid u --kind correction --label false-positive
+```
+
+Synthetic invalid examples must include:
+
+```text
+backscroll sync
+backscroll events query id
+backscroll search term --input claude
+backscroll version
+patterns --kind templates
+`annotate --uuid u --kind correction --label x`
+BACKSCROLL_AUTOUPDATE_DISABLE=1 backscroll status
+```
+
+Tests should call not-yet-defined helpers such as:
+
+```go
+validateSkillMarkdown(root *cobra.Command, path, content string) []skillContractViolation
+```
+
+### Step 3: Run the focused tests and observe RED
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkillContract' -count=1
+```
+
+Expected: compile failure because the contract helper/types do not exist.
+
+### Step 4: Implement the minimum test-only validator
+
+In the same `_test.go` file, add test-only helpers. Requirements:
+
+1. Build the authoritative tree with `buildRootCmd(io.Discard, io.Discard)`.
+2. Derive the set of registered subcommands from `root.Commands()`; do not maintain a duplicate command allowlist.
+3. Read potential `backscroll <command-or-root-flag>` occurrences line by line, with file and 1-based line number.
+4. Treat `--help` and `--version` as supported root forms; treat child `--help` as supported even if Cobra initializes it lazily.
+5. Resolve every other command token through the Cobra tree.
+6. Extract every `--long-flag` in that invocation and require `cmd.Flags().Lookup(name) != nil` (or inherited/persistent equivalent).
+7. Scan shell code-fence lines and inline code spans. If trimmed code begins with a registered subcommand but not `backscroll`, report a bare-subcommand violation.
+8. Reject `BACKSCROLL_AUTOUPDATE_DISABLE` anywhere in tracked guidance.
+9. Ignore URLs and `command -v backscroll` checks that do not contain a command token.
+10. Sort violations by path, line, and message for deterministic failures.
+
+Keep parsing deliberately small and documented. It is a contract for this skill's simple snippets, not a general shell parser.
+
+### Step 5: Run focused and package tests
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkillContract' -count=1
+go test ./cmd/backscroll -count=1
+```
+
+Expected: PASS.
+
+### Step 6: Commit
+
+```bash
+git add cmd/backscroll/skill_contract_test.go
+git commit -m "test(skill): validate documented CLI forms"
+```
+
+### Task 1 review checkpoint
+
+An independent reviewer must verify:
+
+- baseline pressure tests happened before skill edits;
+- command/flag truth comes from Cobra rather than a duplicate list;
+- synthetic stale forms fail for the intended reason;
+- parser scope is deterministic and does not execute snippets;
+- test cannot read user config or mutate a database;
+- no skill Markdown or production code changed.
+
+Fix confirmed blocking/important findings and obtain re-review before Task 2.
+
+## Task 2: Rewrite the main skill around indexed search discipline
+
+**Files:**
+- Modify: `.claude/skills/backscroll/SKILL.md`
+- Modify: `cmd/backscroll/skill_contract_test.go`
+- Reference: `docs/superpowers/specs/2026-08-19-search-discipline-skill-design.md`
+
+### Step 1: Add failing real-skill contract and behavioral-anchor tests
+
+Add:
+
+```go
+func TestBackscrollSkillCommandsMatchCLI(t *testing.T)
+func TestBackscrollSkillContainsSearchDiscipline(t *testing.T)
+```
+
+Use `runtime.Caller(0)` to resolve the repository root from the test source location, then read `.claude/skills/backscroll/SKILL.md`. Do not use process cwd.
+
+`TestBackscrollSkillCommandsMatchCLI` passes the real content through Task 1's validator and reports every violation with `path:line` evidence.
+
+`TestBackscrollSkillContainsSearchDiscipline` requires stable semantic anchors, not the full prose:
+
+```text
+Search discipline (hard rules)
+Drill the top hit
+artifact's vocabulary
+failed invocation is a syntax problem
+Two empty searches prove nothing
+Raw-file boundary
+--source-path
+--indexed-only
+backscroll validate --indexed-only
+```
+
+It must also require an explicit statement that raw `cat`/`jq`/Python/direct `backscroll read` is not a normal retrieval fallback.
+
+### Step 2: Run RED against the current skill
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkillCommandsMatchCLI|TestBackscrollSkillContainsSearchDiscipline' -count=1
+```
+
+Expected failures include:
+
+- missing hard-rule anchors;
+- invalid `backscroll version`;
+- bare `patterns`/`annotate` snippets;
+- any command/flag drift discovered by the static validator.
+
+### Step 3: Correct frontmatter and opening contract
+
+Keep `name`, `user-invocable`, and allowed tools intact. Change the description to trigger-only wording that starts with `Use when` and does not summarize the workflow, for example:
+
+```yaml
+description: "Use when starting feature, bug, test, refactor, or decision work that may have prior session history; when recalling what happened, which command failed, where something ran, or what was decided; and before considering raw coding-agent session files."
+```
+
+Replace “definitive local episodic memory” with “primary local episodic index” and explicitly separate hit evidence from absence uncertainty.
+
+### Step 4: Correct canonical search examples
+
+- Use cwd-inferred project scope by omitting `--project` on the first query.
+- Keep an explicit second `--all-projects` query.
+- Remove the broken `$result` shell pseudocode.
+- Keep valid `--robot`, `--fields`, `--max-tokens`, and `--content-type tool` usage.
+- If an explicit project example remains, use a semantic project ID such as `--project backscroll`, never `<cwd>`.
+
+### Step 5: Add the five hard rules
+
+Add `## Search discipline (hard rules)` after query patterns.
+
+1. **Drill the top hit** with indexed rows from the returned path:
+
+```bash
+SOURCE_PATH="<result_N_source_path>"
+backscroll search "" --all-projects --indexed-only --source-path "$SOURCE_PATH" --robot --fields full --max-tokens 4000
+```
+
+2. **Artifact vocabulary**: literal speaker names, boilerplate, IDs, errors, and artifact language.
+3. **Syntax recovery**: check `backscroll <command> --help`, correct, retry once; never cite one malformed call as tool failure.
+4. **Two empty searches**: literal query, all-projects, indexed source-path/UUID probe, one normal search autosync, repeat probe, status + validate, report gap.
+5. **Raw-file boundary**: no `cat`, `jq`, Python JSONL, `ls` session hunting, or direct `backscroll read` unless the user explicitly authorizes indexing-bug diagnosis after the gap is reported.
+
+Use only commands accepted by the contract test. Do not mention removed commands even negatively in runnable syntax.
+
+### Step 6: Consolidate degradation and troubleshooting
+
+- Point no-result handling to the hard rules rather than “manual human recall.”
+- Preserve full diagnostic output; remove `grep` filtering.
+- Reserve `rebuild` for explicit index/FTS corruption, not missing input discovery.
+- Correct version check to `backscroll --version`.
+- Remove direct-file `read` from indexed retrieval references.
+- Keep useful tokenizer and budget guidance without duplicating the hard rules.
+
+### Step 7: Correct pattern/classification snippets
+
+Prefix every executable form:
+
+```bash
+backscroll patterns ...
+backscroll annotate ...
+```
+
+Change conceptual inline `` `search` `` references that resemble bare commands to `` `backscroll search` `` where needed so the anti-drift contract remains unambiguous.
+
+### Step 8: Run GREEN automated tests
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkill' -count=1
+go test ./cmd/backscroll -count=1
+```
+
+Expected: PASS.
+
+### Step 9: Rerun equivalent pressure scenarios with the edited skill
+
+Dispatch two fresh read-only subagents. Tell them to read the modified `.claude/skills/backscroll/SKILL.md` first, then answer scenarios equivalent to Task 1.
+
+Success criteria for both:
+
+- drill the returned top source path before hunting sessions;
+- use artifact-literal English terms for the English transcript;
+- consult current help and correct malformed syntax;
+- use one normal search for autosync, then indexed-only path probe;
+- run status/validate and report the gap;
+- do not invent removed commands;
+- do not choose raw parsing without explicit diagnostic authorization.
+
+If either agent rationalizes a forbidden fallback, strengthen only the relevant rule/rationalization counter and rerun that scenario. Do not add unrelated prose.
+
+### Step 10: Commit
+
+```bash
+git add .claude/skills/backscroll/SKILL.md cmd/backscroll/skill_contract_test.go
+git commit -m "docs(skill): enforce indexed search discipline"
+```
+
+### Task 2 review checkpoint
+
+An independent reviewer must verify:
+
+- main skill commands/flags match current Cobra;
+- all five rules address the observed issue without obsolete examples;
+- top-hit drill remains inside SQLite;
+- autosync guidance uses normal search, not invented commands;
+- raw-file exception is conditional on explicit user authorization;
+- post-edit pressure agents comply;
+- description is trigger-only and frontmatter remains valid;
+- guidance is concise enough for a frequently loaded skill and existing duplication was reduced where practical.
+
+Fix confirmed findings and obtain re-review before Task 3.
+
+## Task 3: Reconcile context mode and protect both tracked files
+
+**Files:**
+- Modify: `.claude/skills/backscroll/ref-context-mode.md`
+- Modify: `cmd/backscroll/skill_contract_test.go`
+
+### Step 1: Add the failing context-file test
+
+Add:
+
+```go
+func TestBackscrollContextModeCommandsMatchCLI(t *testing.T)
+```
+
+Read the context file with the same source-relative helper and pass it through the contract validator. Add semantic assertions that:
+
+- `--input` is absent;
+- session-only search uses `--source session`;
+- output still requires exactly `Backscroll`, `Rootline`, and `Gaps` sections;
+- the recipe points back to main search discipline or preserves its indexed boundary.
+
+### Step 2: Run RED
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollContextModeCommandsMatchCLI' -count=1
+```
+
+Expected: FAIL on current `list --input claude` and `search --input claude`.
+
+### Step 3: Rewrite context-mode commands minimally
+
+Use valid forms:
+
+```bash
+backscroll validate --indexed-only
+backscroll status --indexed-only
+backscroll list --limit 10 --all-projects --json
+```
+
+For query retrieval, use normal search when freshness/autosync is desired:
+
+```bash
+backscroll search "$PROJECT_SLUG context decisions handoff blockers" --all-projects --max-tokens 4000
+```
+
+For a session-only fallback:
+
+```bash
+backscroll search "$PROJECT_SLUG" --source session --all-projects --max-tokens 4000
+```
+
+Do not add a nonexistent source flag to `list`. Preserve optional Rootline gates and the exact three-section output contract. Add a short requirement to follow the main skill's search discipline for empty results and gaps rather than copying all rules.
+
+### Step 4: Run focused and full command tests
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkill|TestBackscrollContextMode' -count=1
+go test ./cmd/backscroll -count=1
+```
+
+Expected: PASS.
+
+### Step 5: Scan tracked skill guidance for stale forms
+
+```bash
+rg -n 'backscroll (sync|events|sessions|version)\b|--input\b|BACKSCROLL_AUTOUPDATE_DISABLE|^\s*(patterns|annotate)\s+--' .claude/skills/backscroll
+```
+
+Expected: no matches. If explanatory prose must discuss a removed concept, phrase it without a runnable stale command form.
+
+### Step 6: Commit
+
+```bash
+git add .claude/skills/backscroll/ref-context-mode.md cmd/backscroll/skill_contract_test.go
+git commit -m "docs(skill): reconcile context retrieval commands"
+```
+
+### Task 3 review checkpoint
+
+An independent reviewer must verify:
+
+- no removed `--input` remains;
+- list/search scopes are supported by current CLI;
+- context search freshness semantics are intentional;
+- main discipline is referenced, not duplicated inconsistently;
+- optional Rootline behavior and output contract are unchanged;
+- real-file contract test covers both tracked skill files.
+
+Fix confirmed findings and obtain re-review before final verification.
+
+## Task 4: Whole-branch review, verification, and dedicated PR
+
+**Files:**
+- Review: `origin/main...HEAD`
+- Modify: only files required by confirmed review findings
+
+### Step 1: Run independent whole-branch review
+
+Review issue #30, approved design, plan, pressure-test evidence, command-contract parser, both skill files, and repository constraints.
+
+Explicitly verify:
+
+- no CLI/storage/schema implementation changes;
+- no stale runnable command survives;
+- no installed external skill copy is committed;
+- no #31/#33/#35 work is duplicated;
+- anti-drift failures include actionable file:line evidence;
+- rules are hard enough to resist time pressure and raw-file convenience.
+
+Fix blocking/important findings and obtain re-review.
+
+### Step 2: Run format/static and whitespace gates
+
+```bash
+just check
+git diff --check origin/main...HEAD
+```
+
+Expected: PASS.
+
+### Step 3: Run fresh full tests and CI
+
+```bash
+just test
+just ci
+```
+
+Expected: PASS with aggregate statement coverage at or above 85%.
+
+### Step 4: Inspect branch scope
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff --name-status origin/main...HEAD
+```
+
+Expected changed files:
+
+```text
+.claude/skills/backscroll/SKILL.md
+.claude/skills/backscroll/ref-context-mode.md
+cmd/backscroll/skill_contract_test.go
+docs/superpowers/specs/2026-08-19-search-discipline-skill-design.md
+docs/superpowers/plans/2026-08-19-search-discipline-skill.md
+```
+
+Only confirmed review-fix files may extend this list.
+
+### Step 5: Push and open PR
+
+Push `docs/issue-30-search-discipline` and open a dedicated PR using the repository template. The PR body must include:
+
+- `Fixes #30`;
+- the four observed failure modes plus raw-file boundary;
+- explanation that issue proposal examples were translated to current v3 commands;
+- automated Cobra/documentation anti-drift coverage;
+- baseline and post-edit pressure-test summary;
+- exact `just check`, `just test`, and `just ci` evidence.
+
+### Step 6: Review and merge workflow
+
+Dispatch an independent `requesting-code-review` reviewer in this worktree while other issue work may continue elsewhere. After CI and review are green, squash-merge under the repository policy (no external approval count required for `pablontiv`). Confirm `origin/main` contains the squash commit before closing the task.

--- a/docs/superpowers/specs/2026-08-19-search-discipline-skill-design.md
+++ b/docs/superpowers/specs/2026-08-19-search-discipline-skill-design.md
@@ -1,0 +1,348 @@
+# Backscroll Search-Discipline Skill Design
+
+**Date:** 2026-08-19
+**Issue:** [#30 — SKILL.md: add search-discipline guardrails](https://github.com/pablontiv/backscroll/issues/30)
+
+## Summary
+
+Agents with the Backscroll skill loaded have still abandoned indexed retrieval and parsed raw session JSONL after four recoverable moments: dismissing a relevant top-ranked hit, searching with conversational rather than artifact vocabulary, treating one malformed invocation as a tool failure, and encountering an apparent indexing gap.
+
+The repository skill also contains command drift. Its main recipe uses semantically misleading project examples and an invalid version command; its pattern examples omit the `backscroll` executable; and `ref-context-mode.md` uses removed `--input` flags. The issue's paste-ready proposal cannot be copied literally because it references removed `events query` and `sync` commands.
+
+This change will make the tracked skill the canonical, current-CLI search recipe. It adds hard search-discipline rules expressed only with supported v3 commands, reconciles the companion context-mode recipe, and adds a Go contract test that checks documented Backscroll commands and flags against the actual Cobra tree so stale command forms fail CI.
+
+## Goals
+
+- Require agents to inspect a relevant top-ranked result before searching for a different session.
+- Require pasted artifacts to be queried with literal vocabulary from the artifact and in the artifact's language.
+- Treat the first failed invocation as a possible syntax error and require checking current `--help` before abandoning Backscroll.
+- Make two empty searches insufficient evidence that a topic or file is absent.
+- Provide a current-CLI procedure for distinguishing query mismatch from an indexing gap.
+- Make raw JSONL parsing an explicit exceptional diagnostic boundary, never the normal retrieval fallback.
+- Reconcile current command drift in the tracked main skill and `ref-context-mode.md`.
+- Add automated anti-drift coverage for command names and flags used by both skill files.
+- Deliver the work through a dedicated PR for issue #30.
+
+## Non-goals
+
+- Implementing or restoring `events query`, `sync`, `sessions query`, or any other removed CLI surface.
+- Fixing the separate 14 MB indexing gap reported in the issue.
+- Changing search ranking, FTS tokenization, autosync, storage, or schema behavior.
+- Executing every documented command during tests or reading a user's real index.
+- Adding a new skill installation destination or changing pre-push/post-merge distribution hooks.
+- Editing untracked external copies under `~/.agents`; `.claude/skills/backscroll` remains the versioned source of truth.
+- Rewriting historical roadmap/spec documents that describe older CLI generations.
+
+## Existing Problems
+
+### Search behavior guidance
+
+The current skill says empty results do not prove nonexistence, but it does not tell an agent to:
+
+- drill into the top hit by indexed `source_path`;
+- use literal artifact vocabulary;
+- recover from malformed syntax;
+- verify whether a known source path has any indexed rows;
+- report an indexing gap before crossing into raw-file inspection.
+
+Consequently, the agent can follow the broad recall-first intent while still abandoning the indexed path at the exact moments observed in issue #30.
+
+### Main skill command drift
+
+The tracked `.claude/skills/backscroll/SKILL.md` currently contains these weaknesses:
+
+- `--project <cwd-or-inferred>` suggests passing a filesystem path, while project scoping is already inferred from cwd and `--project` expects a project identifier.
+- The fallback shell example checks an unassigned `$result` variable.
+- `backscroll version` is not a command; the supported form is `backscroll --version`.
+- Pattern-discovery examples use bare `patterns` and `annotate`, which are not executables.
+- Troubleshooting recommends `rebuild` as a generic answer to zero results even though a missing discovered source is not necessarily FTS corruption.
+- “Definitive” memory language overstates what an index can prove when a source was never ingested.
+
+### Context-mode drift
+
+`.claude/skills/backscroll/ref-context-mode.md` uses removed `--input claude` flags on `list` and `search`. The supported source restriction is `--source session` on search; list has no `--input` or `--source` flag.
+
+## Design
+
+### 1. Position Backscroll as primary indexed evidence
+
+Change the opening guarantee from “definitive local episodic memory” to “primary local episodic index” or equivalent. The skill remains mandatory recall-first guidance, but it explicitly states:
+
+- a hit is evidence;
+- an empty query result is not evidence that the underlying event or artifact never existed;
+- an absent source-path probe is an indexing-gap signal, not permission to silently replace indexed retrieval with raw parsing.
+
+This wording preserves strong use of Backscroll without making false completeness claims.
+
+### 2. Canonical project-first retrieval
+
+The first search relies on Backscroll's existing cwd-based project inference and does not pass a filesystem path to `--project`:
+
+```bash
+backscroll search "QUERY" --robot --fields minimal --max-tokens 2000
+```
+
+If the result is empty or irrelevant, the agent explicitly runs the all-projects variant:
+
+```bash
+backscroll search "QUERY" --all-projects --robot --fields minimal --max-tokens 2000
+```
+
+The recipe will not include broken shell pseudocode around an unassigned result variable. It describes the two deterministic steps directly.
+
+Execution-shaped queries continue to use `--content-type tool` and terms of at least three characters because the trigram limitation remains real.
+
+### 3. Search discipline hard rules
+
+Add a dedicated section after query patterns.
+
+#### Rule 1: Drill the top hit
+
+If a top-ranked result has relevant keywords, the agent must inspect the indexed rows from that exact `source_path` before changing session hypotheses. Timestamp or assumptions about session contents are not sufficient reasons to dismiss it.
+
+The supported indexed drill-down is:
+
+```bash
+SOURCE_PATH="<result_N_source_path>"
+backscroll search "" --all-projects --indexed-only --source-path "$SOURCE_PATH" --robot --fields full --max-tokens 4000
+```
+
+This reads rows already stored in SQLite. It does not invoke direct-file `read` and does not parse source JSONL.
+
+#### Rule 2: Use artifact vocabulary
+
+For pasted transcripts, logs, error dumps, generated reports, and similar artifacts, the agent must query literal strings likely to appear in the artifact:
+
+- speaker/display names;
+- platform boilerplate;
+- exact identifiers;
+- error fragments;
+- artifact language rather than the conversation's translated paraphrase.
+
+A conceptual description in another language may be a useful secondary search, but not the only evidence before declaring absence.
+
+#### Rule 3: Recover from malformed syntax
+
+A warning, unknown flag, missing argument, “query required,” or session/path resolution error is treated as a syntax problem until the current command help is checked:
+
+```bash
+backscroll search --help
+backscroll list --help
+```
+
+The agent corrects the invocation and retries once. One malformed invocation never justifies switching to raw files.
+
+The recipe does not mention removed `events query` syntax.
+
+#### Rule 4: Two empty searches prove nothing
+
+Before concluding that content is not indexed, the agent must:
+
+1. retry with one or more artifact-literal terms;
+2. broaden from inferred project scope to `--all-projects` when appropriate;
+3. if a source path or UUID is known, probe indexed rows directly:
+
+```bash
+backscroll search "" --all-projects --indexed-only --source-path "*SESSION-UUID*" --json --fields minimal --limit 1
+```
+
+4. run one normal literal search without `--indexed-only`, allowing the existing search autosync to run, then repeat the indexed-only source-path probe;
+5. if still absent, run diagnostics:
+
+```bash
+backscroll status
+backscroll validate --indexed-only
+```
+
+6. report the source path, literal probe, search scopes, and diagnostic output as an indexing gap.
+
+The skill never recommends a nonexistent `backscroll sync` command. It also does not prescribe `rebuild` for a missing source; `rebuild` repairs/re-derives an existing index and is not proof that input discovery can see the file.
+
+#### Rule 5: Raw-file boundary
+
+The skill explicitly prohibits normal fallback to `cat`, `jq`, Python JSONL parsing, `ls`-driven session hunting, or direct-file `backscroll read` after retrieval uncertainty.
+
+Raw-file inspection is allowed only when the user explicitly asks to diagnose the indexing bug or authorizes leaving the indexed-evidence boundary. Before doing so, the agent must report the gap and commands already attempted. Raw inspection may diagnose ingestion; it must not silently substitute for indexed recall.
+
+### 4. Consolidate degradation guidance
+
+Update the existing degradation/troubleshooting sections to refer to the hard rules instead of contradicting or duplicating them.
+
+- Stale/locked/unhealthy index: preserve full Backscroll diagnostics rather than piping them through `grep` and losing context.
+- No results: follow artifact vocabulary, scope broadening, and source-path probe; do not jump directly to “manual human recall.”
+- Suspected missing input: allow one normal search autosync, then indexed-only probe and report.
+- FTS corruption: `rebuild` may remain documented only as an explicit corruption remediation, not a generic missing-source action.
+- Version check: use `backscroll --version`.
+- References: do not present direct-file `read` as the indexed retrieval route.
+
+### 5. Correct command examples
+
+Make all runnable examples use the actual executable:
+
+```text
+backscroll patterns ...
+backscroll annotate ...
+```
+
+Remove the filesystem placeholder from `--project`; examples either use implicit cwd project scope, an explicit semantic project ID such as `--project backscroll`, or `--all-projects`.
+
+Keep valid agent-output flags (`--robot`, `--fields`, `--max-tokens`) and current query filters.
+
+### 6. Reconcile context mode
+
+Update `.claude/skills/backscroll/ref-context-mode.md`:
+
+- remove every `--input claude` use;
+- list recent indexed entries with valid `list` flags;
+- use `--source session` on the broader search when session-only scope is required;
+- keep current status/validate gates and the three-section output contract;
+- use normal search where a fresh autosync is desired and `--indexed-only` only when explicitly inspecting the existing snapshot.
+
+The context recipe must obey the same search discipline and may link back to the main skill rather than copy all five rules.
+
+## Automated Anti-drift Contract
+
+### Location
+
+Add `cmd/backscroll/skill_contract_test.go`. The command package already owns the actual Cobra tree through `buildRootCmd`, making it the authoritative place to compare documentation against implemented commands and flags.
+
+The test locates tracked skill files relative to the Go source file using `runtime.Caller`, not the process working directory:
+
+```text
+.claude/skills/backscroll/SKILL.md
+.claude/skills/backscroll/ref-context-mode.md
+```
+
+This keeps it hermetic under `go test`, scrubbed HOME, and arbitrary checkout locations.
+
+### Command validation
+
+Extract lowercase `backscroll <token>` command forms from both Markdown files. For each occurrence:
+
+- `backscroll --version` and `backscroll --help` are validated as supported root forms;
+- every command token must match a command registered by `buildRootCmd`;
+- `backscroll version`, `backscroll sync`, `backscroll events`, and any future removed command fail automatically because they are absent from the Cobra tree.
+
+The extractor ignores URLs and prose where `backscroll` is not followed by a command token.
+
+### Flag validation
+
+For each documented command invocation, extract `--long-flag` tokens and require that the selected Cobra command exposes each flag. This catches removed forms such as `--input` without maintaining a complete hand-written allowlist.
+
+Shell redirection, comments, quoted query text, variables, and placeholders are not executed. The test statically validates only command/flag registration and therefore cannot access a user's config or database.
+
+### Unprefixed command validation
+
+Inspect shell code-fence lines. If a line begins with a known Backscroll subcommand such as `patterns` or `annotate` but lacks the `backscroll` executable, fail with file and line number.
+
+This catches the current census/classification examples that look executable but are not.
+
+### Explicit invariants
+
+In addition to dynamic Cobra checks, assert that:
+
+- `BACKSCROLL_AUTOUPDATE_DISABLE` does not appear in tracked skill guidance because autoupdate has no runtime opt-out;
+- both hard-rule headings/anchor phrases and the source-path probe are present;
+- raw-file fallback is explicitly prohibited;
+- the context-mode file contains no `--input` token.
+
+These checks protect user-visible behavioral intent that command-tree validation alone cannot express.
+
+## Data Flow
+
+### Ranked hit drill-down
+
+```text
+project-scoped search
+  -> relevant top hit
+  -> capture indexed source_path
+  -> empty-query + --indexed-only + --source-path
+  -> inspect stored rows from that hit
+  -> answer/refine from indexed evidence
+```
+
+### Empty-result escalation
+
+```text
+empty conversational query
+  -> artifact-literal query
+  -> all-projects query
+  -> known source-path/UUID indexed-only probe
+  -> one normal search autosync
+  -> repeat indexed-only probe
+  -> status + validate
+  -> report indexing gap
+  -> raw inspection only with explicit diagnostic authorization
+```
+
+### CI anti-drift
+
+```text
+tracked skill Markdown
+  -> extract backscroll command forms + flags
+  -> compare with buildRootCmd Cobra tree
+  -> reject missing commands/flags and unprefixed subcommands
+  -> go test / CI failure with file:line evidence
+```
+
+## Error Handling
+
+- Missing tracked skill file: contract test fails with its expected repository path.
+- Unreadable skill file: contract test fails with contextual read error.
+- Unknown documented command: fail with file, line, and command token.
+- Unknown documented flag: fail with file, line, selected command, and flag.
+- Complex shell line the static extractor cannot classify: keep the snippet simple rather than weakening validation globally.
+- Empty search output: handled by search discipline; not converted into proof of absence.
+- Autosync or compatibility diagnostic failure: preserve and report full output; do not serve raw-file-derived recall as if it came from the index.
+- Known source absent after retry: report indexing gap; do not run destructive or unrelated remediation automatically.
+
+## Testing
+
+### Contract tests
+
+- Current corrected main skill passes command validation.
+- Current corrected context-mode skill passes command validation.
+- A table of synthetic snippets proves rejection of:
+  - unknown root command;
+  - valid command with unknown flag;
+  - bare known subcommand without `backscroll` prefix;
+  - stale autoupdate opt-out.
+- Synthetic valid snippets prove support for root `--version`, search flags, list flags, patterns flags, and annotate flags.
+- Required discipline anchors and raw-boundary language are present.
+
+### Regression checks
+
+```bash
+go test ./cmd/backscroll -run 'TestBackscrollSkill' -count=1
+go test ./cmd/backscroll -count=1
+just check
+just test
+just ci
+git diff --check origin/main...HEAD
+```
+
+The release-blocking aggregate coverage must remain at or above 85%.
+
+## Documentation and Distribution
+
+The PR changes the versioned source files only:
+
+```text
+.claude/skills/backscroll/SKILL.md
+.claude/skills/backscroll/ref-context-mode.md
+```
+
+Existing pre-push/post-merge hooks remain responsible for copying the versioned skill to `~/.claude/skills/backscroll`. The PR does not edit an external installed copy directly and does not add a second installation mechanism.
+
+`CLAUDE.md` does not require a package-layout update because no Go package is added or removed. It may mention the anti-drift test only if needed for maintenance clarity; otherwise the committed spec and test name are sufficient.
+
+## PR and Integration
+
+Issue #30 receives its own branch and PR. The branch is based on `main` after merged PRs #36 and #37. Required workflow:
+
+1. TDD implementation in the issue #30 worktree.
+2. Independent per-task review.
+3. Independent whole-branch review.
+4. Fresh `just check`, `just test`, and `just ci` evidence.
+5. Dedicated PR with `Fixes #30`.
+6. After CI and independent review pass, squash-merge using the repository's current protection policy.


### PR DESCRIPTION
## What

- Add hard search-discipline rules to the Backscroll agent skill.
- Require indexed top-hit drill-down, artifact-literal vocabulary, syntax recovery, and source-path gap probes before absence claims.
- Make raw JSONL/SQLite/direct-file inspection an explicitly authorized indexing-diagnostic boundary rather than a retrieval fallback.
- Reconcile `ref-context-mode.md` with the current v3 CLI.
- Add a Cobra-backed contract test that rejects stale documented commands, flags, and unprefixed subcommands with file:line diagnostics.

## Why

Agents with the skill loaded still abandoned indexed retrieval after four recoverable moments: dismissing an older top hit, querying an English artifact through translated paraphrases, treating one malformed invocation as tool failure, and encountering an apparent indexing gap.

The tracked recipes also contained stale forms such as `--input`, an invalid version command, and bare `patterns`/`annotate` invocations.

Fixes #30

## How

- Translate the issue's proposed guardrails to supported v3 surfaces: `search --source-path`, empty-query `--indexed-only` probes, one normal-search autosync attempt, and `status`/`validate` diagnostics.
- Keep drill-down inside SQLite; direct `backscroll read`, shell parsing, and raw JSONL require explicit diagnostic authorization after the gap is reported.
- Validate tracked Markdown against `buildRootCmd` rather than maintaining a duplicate command/flag allowlist.
- Cover both the main skill and context-mode companion using source-relative file lookup.

### Behavioral pressure evidence

Before the edit:
- one agent drilled the top hit through direct `backscroll read` and raw paths;
- another recommended direct SQLite, immediate `read`/`tail`, a term-constrained path probe, and a stale-cache behavior that no longer exists.

After the edit, two fresh agents independently:
- drilled the ranked source with `search "" --indexed-only --source-path`;
- corrected syntax and artifact language;
- probed the path before/after exactly one normal autosync search;
- collected diagnostics and reported the gap;
- refused raw inspection without explicit authorization.

## Verification

- `just check` — PASS
- `just test` — PASS
- `just ci` — PASS, aggregate coverage 85.0%
- `git diff --check origin/main...HEAD` — PASS
- Per-task independent reviews — PASS
- Whole-branch independent review — READY

## Checklist

- [x] Tests pass (`just test`)
- [x] Code is clean (`just check`)
- [x] Snapshots updated if needed (not applicable)
- [x] Changes are documented if user-facing
