### PR TITLE
chore: ignore local agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@ graphify-out/
 
 # macOS system files
 .DS_Store
-# Local Pi runtime state
+# Local agent runtime state
 .atl/
 .codegraph/
+.pi/subagents-debug.log
+.worktrees/
 
 # Calibration worksheets carry private session text — never commit
 docs/eval/corrections-labeling-*.csv


### PR DESCRIPTION
## What

- Ignore project-local `.worktrees/` directories.
- Ignore Pi subagent debug logs at `.pi/subagents-debug.log`.

## Why

A detached-HEAD audit found these two legitimate maintenance rules mixed into a rescued commit chain. The issue implementation and documentation are already present in `main`; rejected recovery test experiments are intentionally excluded. This PR preserves only the safe repository-local ignore behavior.

## Verification

- `go test ./...` — PASS on clean branch baseline
- `git diff --check` — PASS
- `git check-ignore -v .pi/subagents-debug.log .worktrees/example` — PASS
- pre-commit `gofmt --check`, `go vet`, and gitleaks — PASS