### PR TITLE
fix(compat): recognize development V13 lineage

### DIFF
--- a/cmd/backscroll/compat_diagnostics_test.go
+++ b/cmd/backscroll/compat_diagnostics_test.go
@@ -520,6 +520,40 @@ func TestLiveWALDiagnosticDoesNotClaimMigrationFailureOrRecovery(t *testing.T) {
 	})
 }
 
+func TestRecoveryContinuationExecutesInConfiguredSamePathContextWithEmptyWAL(t *testing.T) {
+	dbPath := newFixtureIndexDB(t, "v13-development-alter-built.sql")
+	setIndexPolicyEnv(t, dbPath, t.TempDir())
+	walPath := dbPath + "-wal"
+	if err := os.WriteFile(walPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty WAL: %v", err)
+	}
+	before := snapshotSQLiteFiles(t, dbPath)
+	walBefore, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat empty WAL before continuation: %v", err)
+	}
+
+	diagnostic := continuationFor(compat.Diagnostic{Code: compat.CodeUnsupportedLineage, Summary: "fixture diagnostic"}, dbPath)
+	var stdout, stderr bytes.Buffer
+	if err := run(&stdout, &stderr, diagnostic.Continuation); err != nil {
+		t.Fatalf("execute continuation %v: %v\nstdout=%q stderr=%q", diagnostic.Continuation, err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery dry run") {
+		t.Fatalf("continuation output = %q, want recovery dry run", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("continuation stderr = %q, want empty", stderr.String())
+	}
+	assertSQLiteFilesUnchanged(t, dbPath, before)
+	walAfter, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat empty WAL after continuation: %v", err)
+	}
+	if walAfter.Size() != 0 || walAfter.Mode() != walBefore.Mode() || !walAfter.ModTime().Equal(walBefore.ModTime()) {
+		t.Fatalf("empty WAL metadata changed: before=%+v after=%+v", walBefore, walAfter)
+	}
+}
+
 func TestBlockingDiagnosticsHaveExecutableContinuations(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/compat/catalog_test.go
+++ b/internal/compat/catalog_test.go
@@ -194,11 +194,81 @@ func TestFixtureMigrationRowsMatchPublishedCurrentLedger(t *testing.T) {
 				if !ok {
 					t.Fatalf("fixture has unknown migration version %d", row.version)
 				}
+				if filepath.Base(fixturePath) == "v13-development-alter-built.sql" && row.version == 9 {
+					const historicalV9Checksum = "a84857185adb25a812c78f05b1ba4ee4d28e52b52b28812e077c03e7ae539917"
+					if row.name != expected.name || row.checksum != historicalV9Checksum {
+						t.Fatalf("observed development migration 9 row = (%q, %q), want (%q, %q)", row.name, row.checksum, expected.name, historicalV9Checksum)
+					}
+					continue
+				}
 				if row.name != expected.name || row.checksum != expected.checksum {
 					t.Fatalf("migration %d row = (%q, %q), want (%q, %q)", row.version, row.name, row.checksum, expected.name, expected.checksum)
 				}
 			}
 		})
+	}
+}
+
+func TestObservedDevelopmentV13IsStructurallyEquivalentToLegacyV13(t *testing.T) {
+	development := openFixtureCopy(t, "v13-development-alter-built.sql")
+	defer development.Close()
+	legacy := openFixtureCopy(t, "v13-legacy-alter-built.sql")
+	defer legacy.Close()
+
+	developmentShape, err := inspectShape(context.Background(), development)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyShape, err := inspectShape(context.Background(), legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(developmentShape.columnsByTable, legacyShape.columnsByTable) {
+		t.Fatal("development V13 columns differ from supported legacy V13")
+	}
+
+	developmentObjects, err := loadSQLiteObjects(context.Background(), development)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyObjects, err := loadSQLiteObjects(context.Background(), legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(developmentObjects) != len(legacyObjects) {
+		t.Fatalf("SQLite object counts differ: development=%d legacy=%d", len(developmentObjects), len(legacyObjects))
+	}
+	for i := range developmentObjects {
+		got, want := developmentObjects[i], legacyObjects[i]
+		if got.typ != want.typ || got.name != want.name || got.table != want.table {
+			t.Fatalf("SQLite object %d identity differs: development=%+v legacy=%+v", i, got, want)
+		}
+		if got.name != "search_items" && got.sql != want.sql {
+			t.Fatalf("SQLite object %s SQL differs outside documented search_items DDL", got.name)
+		}
+	}
+
+	developmentSQL, err := fs.ReadFile(releaseSchemaFS, "testdata/release-schemas/v13-development-alter-built.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacySQL, err := fs.ReadFile(releaseSchemaFS, "testdata/release-schemas/v13-legacy-alter-built.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	developmentRows := loadFixtureMigrationRows(t, developmentSQL)
+	legacyRows := loadFixtureMigrationRows(t, legacySQL)
+	if len(developmentRows) != len(legacyRows) {
+		t.Fatalf("migration row counts differ: development=%d legacy=%d", len(developmentRows), len(legacyRows))
+	}
+	for i := range developmentRows {
+		got, want := developmentRows[i], legacyRows[i]
+		if got.version != want.version || got.name != want.name {
+			t.Fatalf("migration %d identity differs: development=%+v legacy=%+v", i, got, want)
+		}
+		if got.version != 9 && got.checksum != want.checksum {
+			t.Fatalf("migration %d checksum differs outside documented V9 lineage", got.version)
+		}
 	}
 }
 

--- a/internal/compat/schema_test.go
+++ b/internal/compat/schema_test.go
@@ -273,6 +273,44 @@ func TestConservativeSignatureStableForExactSameSQL(t *testing.T) {
 	}
 }
 
+func TestInspectIndexRecognizesObservedDevelopmentV13Shape(t *testing.T) {
+	db := openFixtureCopy(t, "v13-development-alter-built.sql")
+	defer db.Close()
+
+	shape, err := inspectShape(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const observedSignature = "sha256:952e517fe590b0c75a02996b6035ac6bb22143b9a707b6448ad05a592bf015b4"
+	if shape.Signature != observedSignature {
+		t.Fatalf("development V13 signature = %s, want %s", shape.Signature, observedSignature)
+	}
+
+	plan, diag, err := InspectIndex(context.Background(), db)
+	if err != nil || diag != nil {
+		t.Fatalf("inspect error=%v diagnostic=%+v", err, diag)
+	}
+	if plan.From.AppliedVersion != 13 || len(plan.Steps) != 0 {
+		t.Fatalf("development V13 plan = %+v, want current with no steps", plan)
+	}
+}
+
+func TestObservedDevelopmentV13StillRejectsUnknownAlteration(t *testing.T) {
+	db := openFixtureCopy(t, "v13-development-alter-built.sql")
+	defer db.Close()
+	if _, err := db.Exec("CREATE TABLE unexpected_development_shape (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, diag, err := InspectIndex(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag == nil || diag.Code != CodeUnsupportedLineage {
+		t.Fatalf("diagnostic = %+v, want %s", diag, CodeUnsupportedLineage)
+	}
+}
+
 func TestInspectIndexRecognizesCanonicalAndExplicitLegacyV13Shapes(t *testing.T) {
 	for _, fixture := range []string{"v13.sql", "v13-legacy-alter-built.sql", "v13-legacy-existing-schema-migrations.sql"} {
 		t.Run(fixture, func(t *testing.T) {

--- a/internal/compat/testdata/release-schemas/manifest.json
+++ b/internal/compat/testdata/release-schemas/manifest.json
@@ -589,6 +589,14 @@
       "Provenance": "No manifest release tag maps to this partial legacy per-step V6-before-V7 lineage fixture; no release shipped V6 alone."
     },
     {
+      "Fixture": "v13-development-alter-built.sql",
+      "ProvenanceSHA256": "20766795c6e1cc8196310f9146298161791aef9ba6fbc654753ec2c1cd2fed7d",
+      "Signature": "sha256:952e517fe590b0c75a02996b6035ac6bb22143b9a707b6448ad05a592bf015b4",
+      "AppliedVersion": 13,
+      "HasSourceMetadata": false,
+      "Provenance": "Explicit observed pre-release V13 development lineage produced by the historical ALTER migration path with the original V9 checksum; schema-only fixture with no user data."
+    },
+    {
       "Fixture": "v13-legacy-alter-built.sql",
       "ProvenanceSHA256": "b2c09d4fb99893464e99a0d5b990ef84a23d7a46ecefc924ed5820eacc7b86ca",
       "Signature": "sha256:19d65765b8b0d0bb7d1c41692712c395627e005b7aeccca5f887c75be781e314",

--- a/internal/compat/testdata/release-schemas/v13-development-alter-built.sql
+++ b/internal/compat/testdata/release-schemas/v13-development-alter-built.sql
@@ -1,0 +1,211 @@
+-- Observed pre-release V13 development lineage. This fixture contains schema only;
+-- no user rows are included. Its search_items DDL and V9 checksum reproduce the
+-- historical migration path applied by Backscroll during development.
+BEGIN;
+
+CREATE TABLE annotations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_uuid TEXT,
+    source_path TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    label TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'agent',
+    created_at TEXT NOT NULL,
+    UNIQUE(source_path, ordinal, kind)
+);
+
+CREATE TABLE chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id TEXT NOT NULL,
+    chunk_idx INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    created_at INTEGER NOT NULL, embedding BLOB,
+    UNIQUE(source_id, chunk_idx)
+);
+
+CREATE TABLE correction_signals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_uuid TEXT,
+    source_path TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    detector TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    extraction_version INTEGER NOT NULL,
+    UNIQUE(source_path, ordinal, detector)
+);
+
+CREATE TABLE dynamic_stopwords (term TEXT PRIMARY KEY);
+
+CREATE TABLE embedding_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chunk_id INTEGER NOT NULL REFERENCES chunks(id) ON DELETE CASCADE,
+    model_name TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+    dimensions INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE indexed_files (
+    path TEXT PRIMARY KEY,
+    hash TEXT NOT NULL,
+    last_indexed DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE message_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    signature TEXT UNIQUE NOT NULL,
+    normalization_version INTEGER NOT NULL,
+    template_text TEXT NOT NULL,
+    occurrence_count INTEGER NOT NULL DEFAULT 1,
+    first_seen TEXT,
+    last_seen TEXT
+);
+
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    text,
+    content=search_items,
+    content_rowid=id,
+    tokenize='porter unicode61'
+);
+
+CREATE VIRTUAL TABLE messages_vocab USING fts5vocab(messages_fts, 'row');
+
+CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_on TEXT NOT NULL,
+			checksum TEXT NOT NULL
+		);
+
+CREATE TABLE search_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL DEFAULT 'session',
+    source_path TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    text TEXT NOT NULL,
+    timestamp TEXT,
+    uuid TEXT UNIQUE,
+    project TEXT,
+    content_type TEXT NOT NULL DEFAULT 'text', extraction_version INTEGER, was_interrupted INTEGER);
+
+CREATE TABLE session_tags (
+    source_path TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    PRIMARY KEY (source_path, tag)
+);
+
+CREATE TABLE template_matches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    template_id INTEGER NOT NULL,
+    item_uuid TEXT,
+    source_path TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    UNIQUE(source_path, ordinal, template_id),
+    FOREIGN KEY(template_id) REFERENCES message_templates(id)
+);
+
+CREATE TABLE tool_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_uuid TEXT,
+    source_path TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    tool_name TEXT NOT NULL,
+    command_head TEXT,
+    is_error INTEGER,
+    exit_code INTEGER,
+    extraction_version INTEGER NOT NULL,
+    UNIQUE(source_path, ordinal)
+);
+
+CREATE VIRTUAL TABLE tool_fts USING fts5(
+    text,
+    content=search_items,
+    content_rowid=id,
+    tokenize='trigram'
+);
+
+CREATE VIRTUAL TABLE tool_vocab USING fts5vocab(tool_fts, 'row');
+
+CREATE INDEX idx_annotations_kind ON annotations(kind);
+
+CREATE INDEX idx_annotations_uuid ON annotations(item_uuid);
+
+CREATE INDEX idx_chunks_source_id ON chunks (source_id);
+
+CREATE INDEX idx_correction_signals_confidence ON correction_signals(confidence DESC);
+
+CREATE INDEX idx_correction_signals_detector ON correction_signals(detector);
+
+CREATE INDEX idx_correction_signals_source ON correction_signals(source_path);
+
+CREATE INDEX idx_matches_template ON template_matches(template_id);
+
+CREATE INDEX idx_matches_uuid ON template_matches(item_uuid);
+
+CREATE INDEX idx_search_items_project ON search_items(project);
+
+CREATE INDEX idx_search_items_source_path ON search_items(source_path);
+
+CREATE INDEX idx_session_tags_tag ON session_tags(tag);
+
+CREATE INDEX idx_template_matches_source ON template_matches(source_path);
+
+CREATE INDEX idx_templates_sig ON message_templates(signature);
+
+CREATE INDEX idx_templates_version ON message_templates(normalization_version);
+
+CREATE INDEX idx_tool_events_tool ON tool_events(tool_name);
+
+CREATE INDEX idx_tool_events_uuid ON tool_events(message_uuid);
+
+CREATE UNIQUE INDEX idx_tool_events_uuid_unique ON tool_events(message_uuid) WHERE message_uuid IS NOT NULL;
+
+CREATE TRIGGER search_items_ad_msg AFTER DELETE ON search_items
+WHEN old.content_type IN ('text', 'code', 'reasoning') BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.id, old.text);
+END;
+
+CREATE TRIGGER search_items_ad_tool AFTER DELETE ON search_items
+WHEN old.content_type = 'tool' BEGIN
+    INSERT INTO tool_fts(tool_fts, rowid, text) VALUES('delete', old.id, old.text);
+END;
+
+CREATE TRIGGER search_items_ai_msg AFTER INSERT ON search_items
+WHEN new.content_type IN ('text', 'code', 'reasoning') BEGIN
+    INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+CREATE TRIGGER search_items_ai_tool AFTER INSERT ON search_items
+WHEN new.content_type = 'tool' BEGIN
+    INSERT INTO tool_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+CREATE TRIGGER search_items_au_msg AFTER UPDATE ON search_items
+WHEN old.content_type IN ('text', 'code', 'reasoning') BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.id, old.text);
+    INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+CREATE TRIGGER search_items_au_tool AFTER UPDATE ON search_items
+WHEN old.content_type = 'tool' BEGIN
+    INSERT INTO tool_fts(tool_fts, rowid, text) VALUES('delete', old.id, old.text);
+    INSERT INTO tool_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (1, 'V1 core schema', '1970-01-01 00:00:00', '4e07949ccd3912fb3c0e149be9a2e05fdd51f8cedb8df1f28b3bb5ac5afe532a');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (2, 'V2 embedding tables', '1970-01-01 00:00:00', '37dc9627f01f0e2d0fbea6bba5cd9f609d5da05089eeb9541a057dd2290cf8af');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (3, 'V3 embedding blob column', '1970-01-01 00:00:00', '36cd183f10ff84ab4753be027078cdd710b46efdc830053d4a641af725006ea5');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (4, 'V4 tool_fts trigram index', '1970-01-01 00:00:00', '77e59cf515f33c466282e0f3e921377f584794d0b7cade1704f566374a569a55');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (5, 'V5 drop phantom session_events', '1970-01-01 00:00:00', 'aedaab81efb6bc34d3f664468b71c1a716f5b55d5132156cb43bd7462d549c7b');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (6, 'V6 drop phantom source_metadata column', '1970-01-01 00:00:00', 'a327b9b6e7b8f5fe369c9fc08093ac80a87640daa515890af94b269d430e9378');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (7, 'V7 reasoning content_type routes to messages_fts', '1970-01-01 00:00:00', 'a80704442c2a0084f98e4bc53978364b14d1c6bd3bd99ba6119a2a9ecbd685e7');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (8, 'V8 perennity: extraction_version, was_interrupted, tool_events', '1970-01-01 00:00:00', '6853d72ded3bdc775b52507321c31df44bf35e8277719432ca8aa126ee16cec1');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (9, 'V9 tool_events uuid uniqueness index', '1970-01-01 00:00:00', 'a84857185adb25a812c78f05b1ba4ee4d28e52b52b28812e077c03e7ae539917');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (10, 'V10 template mining: message_templates, template_matches', '1970-01-01 00:00:00', '0e548d0cb6c47147726f943bfc860500ca9a9bc821df0601998876ea5e9652c2');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (11, 'V11 correction detection: correction_signals', '1970-01-01 00:00:00', '5a7180f901c5feacb67cd104a61e7b7ba9cec69aaeab1d2b5d723459dc590456');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (12, 'V12 agent classification: annotations (free-form labels; enum freeze deferred)', '1970-01-01 00:00:00', 'b3fb66fd2924a9f07a3e4ec0ba253fc1d6965664615a795be6b22d01ab292108');
+INSERT INTO schema_migrations (version, name, applied_on, checksum) VALUES (13, 'V13 backfill discovery indexes', '1970-01-01 00:00:00', '2172ce531c670806933ffe3005fdc0a2ebb8eb3f84d2bd0d8fa608dddb5d136e');
+COMMIT;

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -936,8 +936,12 @@ func restoreBackup(activePath, backupPath string, backupSidecars []string, plann
 func ensureSourceSidecarsSafe(dbPath string) error {
 	for _, suffix := range sqliteSidecarSuffixes() {
 		path := dbPath + suffix
-		if _, err := os.Lstat(path); err == nil {
+		info, err := os.Lstat(path)
+		if err == nil {
 			if suffix == "-wal" {
+				if info.Mode().IsRegular() && info.Size() == 0 {
+					continue
+				}
 				return fmt.Errorf("%w: unexpected SQLite sidecar namespace entry %s", storage.ErrImmutableReadOnlyWALUnsafe, path)
 			}
 			return fmt.Errorf("unexpected SQLite sidecar namespace entry %s", path)

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1360,6 +1360,25 @@ func TestRecoverRejectsLateActiveSidecarAfterBackup(t *testing.T) {
 }
 
 func TestRecoverSQLiteSidecarPolicy(t *testing.T) {
+	t.Run("empty same-path WAL is safe for dry-run and remains unchanged", func(t *testing.T) {
+		dir := t.TempDir()
+		activePath := filepath.Join(dir, "active.db")
+		createRecoveryDB(t, activePath, []storage.IndexedMessage{{Ordinal: 0, Role: "user", Text: "active with empty WAL", UUID: "22222222-2222-4222-8222-222222222222", ContentType: "text"}})
+		if err := os.WriteFile(activePath+"-wal", nil, 0o600); err != nil {
+			t.Fatalf("write empty WAL: %v", err)
+		}
+		before := snapshotRecoveryDBFile(t, activePath)
+
+		report, err := Execute(context.Background(), Options{ActivePath: activePath, FromPath: activePath, DryRun: true})
+		if err != nil {
+			t.Fatalf("Execute same-path dry run with empty WAL: %v", err)
+		}
+		if !reflect.DeepEqual(report.InputCounts, []int{1}) || report.FinalCount != 1 {
+			t.Fatalf("report = %+v, want one input and one final row", report)
+		}
+		assertRecoveryDBFileSnapshot(t, "same-path source with empty WAL after dry-run", activePath, before)
+	})
+
 	t.Run("stranded non-empty WAL rejected before immutable planning", func(t *testing.T) {
 		dir := t.TempDir()
 		activePath := filepath.Join(dir, "active.db")

--- a/internal/storage/migration_plan_test.go
+++ b/internal/storage/migration_plan_test.go
@@ -80,8 +80,16 @@ func TestCatalogGoLineagesUpgradeLosslessly(t *testing.T) {
 			assertFTSQueryable(t, db.DB(), "sentinelcmd", 0)
 			assertToolFTSQueryable(t, db.DB(), "sentinelcmd", len(want.ToolSearchItems))
 			assertCurrentShape(t, db.DB())
-			if got, wantRows := loadStorageMigrationRows(t, db.DB()), authoritativeCurrentMigrationRows(); !reflect.DeepEqual(got, wantRows) {
-				t.Fatalf("schema_migrations rows differ\ngot:  %+v\nwant: %+v", got, wantRows)
+			wantMigrationRows := authoritativeCurrentMigrationRows()
+			if fixture.name == "v13-development-alter-built.sql" {
+				for i := range wantMigrationRows {
+					if wantMigrationRows[i].Version == 9 {
+						wantMigrationRows[i].Checksum = "a84857185adb25a812c78f05b1ba4ee4d28e52b52b28812e077c03e7ae539917"
+					}
+				}
+			}
+			if got := loadStorageMigrationRows(t, db.DB()); !reflect.DeepEqual(got, wantMigrationRows) {
+				t.Fatalf("schema_migrations rows differ\ngot:  %+v\nwant: %+v", got, wantMigrationRows)
 			}
 
 			snapshotPath := maybeOnlySnapshot(t, dbPath)

--- a/internal/storage/recovery_records.go
+++ b/internal/storage/recovery_records.go
@@ -51,6 +51,7 @@ func readRecordsForSignature(ctx context.Context, q compat.Queryer, signature st
 		"sha256:975656bb5e894e12bd30aa65bb3366ca2bdeee23f59aca8e133b18a62e7ffad5", // v11
 		"sha256:ff136d58048d69f02be857f632750ef3e2daa35fd6ba637f7645986950f83d31", // v12
 		"sha256:ef52be2fb56acd0e51b38506746fa3594ed1de76bb0b5dd180767d3c903fb46d", // v13 canonical
+		"sha256:952e517fe590b0c75a02996b6035ac6bb22143b9a707b6448ad05a592bf015b4", // v13 observed development ALTER-built alias
 		"sha256:19d65765b8b0d0bb7d1c41692712c395627e005b7aeccca5f887c75be781e314", // v13 legacy ALTER-built alias
 		"sha256:f52b4132322f3addb0fc01304f92ca6a2c2f4706e5ac010c59a5ea594cbd25b2": // v13 legacy schema_migrations alias
 		return readCanonicalSearchItems(ctx, q)


### PR DESCRIPTION
## What

Recognize the observed pre-release V13 development index lineage and make the advertised same-path recovery dry run operational when SQLite leaves a zero-byte WAL.

## Why

A valid V13 index produced by Backscroll's development history was rejected as `unsupported_lineage`, blocking every index-backed command. The emitted recovery continuation also failed before inspection when a harmless zero-byte WAL existed.

Closes #41.

## How

- add a schema-only fixture reproducing signature `sha256:952e517fe590b0c75a02996b6035ac6bb22143b9a707b6448ad05a592bf015b4`;
- prove it differs from the supported legacy V13 shape only in the historical `search_items` ALTER-built DDL and V9 checksum;
- register the exact signature in both the compatibility catalog and canonical recovery adapter while preserving fail-closed handling for unknown shapes;
- permit only regular zero-byte WAL files during immutable recovery planning, retaining rejection for symlinks, non-empty WALs, and all other unexpected sidecars;
- execute the emitted `recover --from <active> --dry-run` continuation end-to-end in a CLI regression test and verify source bytes and metadata remain unchanged.

A development binary was also verified against the affected 2.05 GB local index: `backscroll status` succeeded and the database/WAL size, mtime, and inode remained unchanged.

## Checklist

- [x] Tests pass (`just test`)
- [x] Code is clean (`just check`)
- [x] Snapshots updated if needed (not applicable; no Rust snapshots)
- [x] Changes are documented if user-facing (fixture provenance and regression coverage included)
- [x] Full local CI gate passes (`just ci`, aggregate coverage 85.1%)
