### PR TITLE
fix(skills): preserve installs through product-owned runtime links

### DIFF
--- a/.claude/skills/backscroll/SKILL.md
+++ b/.claude/skills/backscroll/SKILL.md
@@ -60,7 +60,7 @@ where `<config_dir>` is the OS config directory, or `BACKSCROLL_CONFIG_DIR`. The
 Use machine-readable, budgeted output:
 
 - Robot mode on search emits `result_N_field=value` lines; search string values escape backslash as `\\`, carriage return as `\r`, and newline as `\n`.
-- `--fields minimal`: returns `source_path`, `snippet`, `score`, `role`, and `timestamp`.
+- `--robot --fields minimal`: emits `result_N_filepath`, `result_N_content` (bounded snippet), `result_N_score`, `result_N_role`, and `result_N_timestamp`. JSON uses `source_path` and `snippet`; do not use those names as robot keys.
 - `--fields full`: use only for a selected source-path drill.
 - `--max-tokens <budget>`: declare and enforce the output budget.
 
@@ -132,7 +132,7 @@ backscroll search "go test" --all-projects --content-type tool --robot --fields 
 1. **Drill the top hit.** If a top-ranked result contains relevant decision keywords, inspect indexed rows from that returned path before dismissing it by age or hunting another session.
 
 ```bash
-SOURCE_PATH="<result_N_source_path>"
+SOURCE_PATH="<decoded result_N_filepath value>"
 backscroll search --text "$QUERY" --all-projects --source-path "$SOURCE_PATH" --robot --fields full --max-tokens 4000
 ```
 

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Post-merge: sync skills, rebuild backscroll, propagate doc aggregates
+# Post-merge: rebuild backscroll, install inputs, propagate doc aggregates
 
 [ -z "$HOME" ] && HOME=$(eval echo ~)
 
@@ -28,14 +28,9 @@ install_input_presets() {
   done
 }
 
-# Install project skills to the Claude user scope.
-SKILLS_DEST="$HOME/.claude/skills"
-mkdir -p "$SKILLS_DEST"
-for skill in backscroll; do
-  rm -rf "${SKILLS_DEST:?}/$skill"
-  cp -r "$REPO_ROOT/.claude/skills/$skill" "$SKILLS_DEST/$skill"
-  echo "backscroll: installed $skill skill → $SKILLS_DEST/$skill"
-done
+# Existing product-owned links follow the stable clone automatically. Never
+# replace skill destinations implicitly; see docs/skill-installation.md.
+echo "backscroll: skills unchanged; explicit installation: docs/skill-installation.md"
 install_input_presets
 
 BACKSCROLL_BIN="${BACKSCROLL_BIN:-$HOME/.local/bin/backscroll}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -90,14 +90,10 @@ install_input_presets() {
   done
 }
 
-# Install project skills to the Claude user scope.
-SKILLS_DEST="$HOME/.claude/skills"
-mkdir -p "$SKILLS_DEST"
-for skill in backscroll backscroll-doctor; do
-  rm -rf "${SKILLS_DEST:?}/$skill"
-  cp -r "$REPO_ROOT/.claude/skills/$skill" "$SKILLS_DEST/$skill"
-  echo "backscroll: installed $skill skill → $SKILLS_DEST/$skill"
-done
+# Skill replacement is an explicit, digest-approved operator action, never a
+# side effect of pushing from a potentially disposable worktree.
+# See docs/skill-installation.md and scripts/install-skills.py.
+echo "backscroll: skills unchanged; explicit installation: docs/skill-installation.md"
 install_input_presets
 
 # Rebuild backscroll binary so the installed version matches the pushed code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,28 @@ jobs:
   gitleaks:
     uses: pablontiv/crossbeam/.github/workflows/gitleaks.yml@v2
 
+  skill-install:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Test isolated skill installation and recipe retrieval
+        run: |
+          mkdir -p .local-evidence
+          go build -o .local-evidence/backscroll ./cmd/backscroll
+          export BACKSCROLL_TEST_BINARY="$PWD/.local-evidence/backscroll"
+          python3 tests/test_skill_install.py -v
+
   release:
     uses: pablontiv/crossbeam/.github/workflows/go-release.yml@v2
     needs: [ci, gitleaks]

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 # Test artifacts
 session_test.json
 coverage.out
+.local-evidence/
+__pycache__/
 
 # Skill eval workspace (local artifacts)
 .claude/skills/backscroll-workspace/iteration-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ External knowledge sources are configured with active `*.inputs.toml` manifests 
 
 - `docs/research/` — Structured research documents: feasibility study and architecture decisions
 - `docs/roadmap/` — Roadmap decomposition (O01–O06): outcomes and tasks with frontmatter metadata
-- `.claude/skills/backscroll/` — Claude Code skill for `/backscroll` (distributed to `~/.claude/skills/` via pre-push hook)
+- `.claude/skills/backscroll/` — canonical skill for Claude, Agents (Codex), and OpenCode. Explicit stable-source installation, approvals, backup/restore and runtime checks are owned by `docs/skill-installation.md` and `scripts/install-skills.py`; Git hooks never replace skills. `just test-skills` runs isolated filesystem and installed-recipe E2E tests.
 - `inputs/` — Shipped input presets (`claude.inputs.toml`, `pi.inputs.toml`, `decisions.inputs.toml`, `opencode.inputs.toml`, `categories.toml`); copied to `<config_dir>/backscroll/inputs/` by `install.sh` and the pre-push hook (skips if already present; `BACKSCROLL_FORCE_INPUTS=1` to overwrite)
 - Documentation is written in a mix of Spanish and English (roadmap fields like `estado`, `tipo` are in Spanish)
 

--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,12 @@ test:
     config_dir="$(mktemp -d)" && trap 'rm -rf "$config_dir"' EXIT && \
     BACKSCROLL_CONFIG_DIR="$config_dir" go test ./...
 
+# Isolated skill installer filesystem + installed-recipe E2E (Python 3.9+)
+test-skills:
+    mkdir -p .local-evidence
+    go build -o .local-evidence/backscroll ./cmd/backscroll
+    BACKSCROLL_TEST_BINARY="$PWD/.local-evidence/backscroll" python3 tests/test_skill_install.py -v
+
 # Build binary
 build:
     go build -o backscroll ./cmd/backscroll

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ On `search`, `--fields minimal|full` controls density and `--max-tokens N` caps 
 
 Backscroll is a CLI. Nothing requires an agent, and there is no MCP server — a CLI call costs a fraction of the tokens an MCP tool schema does.
 
-Agents use the same commands with `--robot --fields minimal --max-tokens N`. A `/backscroll` skill for Claude Code ships in `.claude/skills/backscroll/`, and the pre-push hook installs it to `~/.claude/skills/`.
+Agents use the same commands with `--robot --fields minimal --max-tokens N`. The canonical Backscroll skill ships in `.claude/skills/backscroll/`. The optional [skill installer](docs/skill-installation.md) links Claude, Agents (Codex), and OpenCode to that single source in an explicitly selected stable clone. Installation requires a reviewed inventory digest; existing destinations are backed up and can be restored. Git hooks and binary installers never replace skills implicitly.
 
 ---
 
@@ -283,10 +283,10 @@ git config core.hooksPath .githooks
 Without this, git uses `.git/hooks/` (samples only) and **every push silently skips**:
 
 - the binary rebuild + install into `$HOME/.local/bin/backscroll` (so your installed CLI stays stale vs. the pushed code),
-- the `just coverage-check` gate, and
+- the `just ci` aggregate-coverage gate when Go files change, and
 - the AGENTS.md / docs-update validation.
 
-Once activated, `pre-push` runs those gates and reinstalls the binary, skill, and input presets on every push; `post-merge` reinstalls after a `git pull`/merge. Verify a hook actually fired by running the command you changed from the PATH binary — `go build` reports `version dev` (the release version is injected by CI), so confirm by behavior, not the version string.
+Once activated, `pre-push` runs those gates and reinstalls the binary and input presets on every push; `post-merge` reinstalls them after a `git pull`/merge. Neither hook replaces skill directories. Explicitly installed skill links follow the operator-selected stable clone; see [installation and restoration](docs/skill-installation.md). Verify a hook actually fired by running the command you changed from the PATH binary — `go build` reports `version dev` (the release version is injected by CI), so confirm by behavior, not the version string.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`).
 

--- a/docs/adr/0008-instalar-skills-con-aprobacion-explicita.md
+++ b/docs/adr/0008-instalar-skills-con-aprobacion-explicita.md
@@ -1,0 +1,31 @@
+---
+tipo: adr
+estado: proposed
+fecha: '2026-09-10'
+contexto: 'Los hooks reemplazan la copia Claude y conservan copias obsoletas Agents y OpenCode; issue 62 exige preservar preimagenes y separar mecanismo de despliegue real.'
+decision: 'Proponer instalador explicito Python 3 de biblioteca estandar con inventario y aprobacion por digest, enlaces a clon estable, respaldos y recibos restaurables; quitar sustituciones implicitas de skills de ambos hooks.'
+alternativas: 'Copias automaticas: mantienen divergencia y borran cambios; enlaces desde el directorio actual: pueden apuntar a una copia desechable; nuevo subcomando Go: amplia el CLI y su politica de arranque para una operacion del repositorio.'
+consecuencias: 'Python 3 y Git son requisitos solo del instalador opcional; la actualizacion de un clon estable actualiza los tres destinos; la sustitucion en un hogar real requiere autorizacion independiente.'
+pendientes: 'La verificacion de descubrimiento interactivo depende de las interfaces disponibles sin red; no se autoriza despliegue real.'
+---
+# 0008. Instalar skills con aprobacion explicita
+
+## Contexto
+
+Los hooks reemplazan la copia Claude y conservan copias obsoletas Agents y OpenCode; issue 62 exige preservar preimagenes y separar mecanismo de despliegue real.
+
+## Decisión
+
+Proponer instalador explicito Python 3 de biblioteca estandar con inventario y aprobacion por digest, enlaces a clon estable, respaldos y recibos restaurables; quitar sustituciones implicitas de skills de ambos hooks.
+
+## Alternativas descartadas
+
+Copias automaticas: mantienen divergencia y borran cambios; enlaces desde el directorio actual: pueden apuntar a una copia desechable; nuevo subcomando Go: amplia el CLI y su politica de arranque para una operacion del repositorio.
+
+## Consecuencias
+
+Python 3 y Git son requisitos solo del instalador opcional; la actualizacion de un clon estable actualiza los tres destinos; la sustitucion en un hogar real requiere autorizacion independiente.
+
+## Pendientes
+
+La verificacion de descubrimiento interactivo depende de las interfaces disponibles sin red; no se autoriza despliegue real.

--- a/docs/eval/skill-installation.md
+++ b/docs/eval/skill-installation.md
@@ -1,0 +1,54 @@
+# Skill installation correction (#62)
+
+## Narrow question
+
+Can native installation leave Claude, Agents, and OpenCode resolving the same
+product-owned Backscroll skill, without losing an existing destination's contents,
+and does the installed recipe retrieve a known indexed fixture using robot
+`result_N_filepath` rather than the scout's incorrect `result_N_source_path` oracle?
+
+## Basis and scope
+
+Starting evidence: issue #62 and its isolated reproduction comment (2026-09-10).
+The existing `.githooks/pre-push` replaces only Claude copies with `rm -rf` + `cp`;
+`.githooks/post-merge` independently repeats that behavior. Binary installers do
+not install skills. The product correction must not perform an operator rollout.
+Only temporary HOME fixtures may be replaced during this task.
+
+## Activation-day-1 recall
+
+- Command: `backscroll search "skill installation Claude Agents OpenCode" --robot --fields minimal --max-tokens 2000`.
+- First call: exit 0, four hits, 0.22 seconds wall time. Relevant hits included the
+  previous installation scout and shared-memory product intent; another hit was
+  an unrelated query-echo ADR discussion.
+- Warning: `sync_in_progress`; one permitted identical retry took 0.23 seconds,
+  also exit 0 with the same warning. No additional recall/status/validate calls.
+- Effect: confirmed `result_N_filepath` from the actual robot output and recovered
+  the previous scout context. The issue's complete body and evidence comment,
+  retrieved separately through `gh-axi`, remain the implementation authority.
+- Noise/limits: minimal snippets are not a full investigation report; both calls
+  read committed snapshots while another sync was active. No absence claim.
+
+## Experiment and RED/GREEN
+
+At baseline `82f8bb8`, `go build -o .local-evidence/backscroll ./cmd/backscroll`
+and `python3 tests/skill_install_poc.py .local-evidence/backscroll` succeeded:
+
+| Native pre-push destination | Symlink | Stale recipe retained | Local-note retained |
+|---|---|---|---|
+| Claude | no | no | **no** |
+| Agents | no | **yes** | yes |
+| OpenCode | no | **yes** | yes |
+
+The real dev binary returned `result_0_filepath=<temporary fixture>/recall.md`
+for `installationoraclecobalt`, with no stderr. This corrects the oracle without
+claiming that retrieval was defective.
+
+`python3 tests/test_skill_install.py` then exited 1 with two failures before
+production changes: native pre-push destroyed the Claude sentinel, and the
+explicit preservation-safe installation interface did not yet exist. These
+executable tests are committed separately as the versioned E2E RED. Hook build
+and rootline are stubbed only to isolate installation from unrelated side effects;
+Git, filesystem operations, the hook itself and PoC retrieval are real.
+
+Implementation and final validation results follow after GREEN.

--- a/docs/eval/skill-installation.md
+++ b/docs/eval/skill-installation.md
@@ -10,8 +10,8 @@ and does the installed recipe retrieve a known indexed fixture using robot
 ## Basis and scope
 
 Starting evidence: issue #62 and its isolated reproduction comment (2026-09-10).
-The existing `.githooks/pre-push` replaces only Claude copies with `rm -rf` + `cp`;
-`.githooks/post-merge` independently repeats that behavior. Binary installers do
+At baseline, `.githooks/pre-push` replaced only Claude copies with `rm -rf` + `cp`;
+`.githooks/post-merge` independently repeated that behavior. Binary installers do
 not install skills. The product correction must not perform an operator rollout.
 Only temporary HOME fixtures may be replaced during this task.
 
@@ -35,7 +35,7 @@ At baseline `82f8bb8`, `go build -o .local-evidence/backscroll ./cmd/backscroll`
 and `python3 tests/skill_install_poc.py .local-evidence/backscroll` succeeded:
 
 | Native pre-push destination | Symlink | Stale recipe retained | Local-note retained |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Claude | no | no | **no** |
 | Agents | no | **yes** | yes |
 | OpenCode | no | **yes** | yes |
@@ -47,8 +47,67 @@ claiming that retrieval was defective.
 `python3 tests/test_skill_install.py` then exited 1 with two failures before
 production changes: native pre-push destroyed the Claude sentinel, and the
 explicit preservation-safe installation interface did not yet exist. These
-executable tests are committed separately as the versioned E2E RED. Hook build
+executable tests are committed separately in `1eb5b18` as the versioned E2E RED. Hook build
 and rootline are stubbed only to isolate installation from unrelated side effects;
 Git, filesystem operations, the hook itself and PoC retrieval are real.
 
-Implementation and final validation results follow after GREEN.
+## Fresh production implementation and GREEN
+
+No PoC installer code was promoted into production. The production entrypoint
+is `scripts/install-skills.py`; both Git hooks now leave skills unchanged. The
+explicit installer verifies a clean ordinary source clone, emits a digest-bound
+read-only inventory, preserves previous objects by rename, and links all three
+supported destinations to the same canonical tree. Receipts precede mutation and
+append-only events support restoration even after process exit mid-install.
+The canonical skill itself now distinguishes robot `filepath`/`content` keys from
+JSON `source_path`/`snippet`.
+
+Validated locally on macOS:
+
+- `just check`: passed (gofmt/Go vet).
+- `just test`: passed (all Go packages).
+- `just test-skills`: passed **19 tests** against a dev build, including
+  the original E2E tests, all three destinations, byte/mode/link backups, repeated
+  install, source updates, stale approvals, source provenance, symlink ancestors,
+  drift refusal, partial rollback, process-exit recovery, append-only receipts,
+  uninstall/restore and custom OpenCode config root.
+- Installed-recipe E2E executes the first canonical cwd-inferred search command
+  read through **each** installed link, using a real dev binary and an isolated
+  synthetic Claude input with a registered project. Every target returns the exact
+  fixture `result_0_filepath`; no all-projects fallback is needed.
+- CI includes Linux/macOS filesystem + installed-recipe E2E without agent-runtime
+  dependencies. Local success is not a claim that remote CI already passed.
+
+## Native runtime observations and limits
+
+`python3 tests/skill_runtime_probe.py` runs installed tools with a scrubbed HOME,
+config/cache/data roots, an empty fixture repository, and a macOS sandbox that
+prohibits network access and filesystem writes outside the fixture. No model
+turn, real credentials, real-home replacement, or runtime installation is used.
+
+| Surface | Observation |
+| --- | --- |
+| Codex 0.153.4 / Agents | Native app-server `skills/list` reports exactly one `backscroll`, enabled with user scope, resolving to `<stable-product>/.claude/skills/backscroll/SKILL.md`. |
+| OpenCode 1.18.19 | Native `debug skill --pure` reports the OpenCode lexical `SKILL.md` path and corrected recipe content. The same observation holds with Claude/Agents links temporarily absent, so compatible-path discovery cannot hide a broken OpenCode entry. |
+| Claude Code 2.1.267 | Native `plugin validate` succeeds on the real canonical skills parent with no errors. Validation of the installed parent explicitly warns that its symlink was **not** read. This is validation evidence, **not an observed interactive session discovery**. |
+
+Claude's current official [discovery documentation](https://code.claude.com/docs/en/skills)
+explicitly supports symlinked personal skill folders. A future authorized operator
+rollout must still check `/skills` in the actual session; this task does not claim
+that interactive check. Native probes are optional and version-sensitive. Codex
+also warned that helper aliases are not created under a temporary directory; that
+did not prevent `skills/list` from discovering the skill.
+
+The first Claude target-validation attempt incorrectly passed the individual
+skill directory (interpreted as a plugin with no manifest); correcting the command
+to the canonical **parent skills directory**, per CLI help/documentation, passed.
+This is an experiment invocation correction, not a product defect.
+
+## Remaining operator work
+
+This implements the product-owned mechanism, not the real installed-directory
+rollout. Issue #62 must remain open for fresh real preimage inventory, stable-root
+selection, digest-bound approval, interactive discovery, and restoration evidence
+on the operator's actual destinations. Unsupported copies are not automatically
+removed. No source is vendored into another skills repository. ADR0008 records the
+proposed ownership decision for review; no merge, release or deployment occurred.

--- a/docs/skill-installation.md
+++ b/docs/skill-installation.md
@@ -1,0 +1,155 @@
+# Installing the Backscroll skill
+
+Backscroll owns one canonical skill tree: `.claude/skills/backscroll/` in this
+repository. On macOS/Linux, `scripts/install-skills.py` installs absolute symlinks
+to that tree in an **operator-selected stable ordinary clone**. It requires Python
+3.9+ and Git; these are not dependencies of the Backscroll binary.
+
+| Supported target | Installed entry |
+| --- | --- |
+| Claude Code | `<home>/.claude/skills/backscroll` |
+| Agents-compatible discovery (Codex) | `<home>/.agents/skills/backscroll` |
+| OpenCode | `<config-home>/opencode/skills/backscroll` |
+
+`--home` and `--source-root` are mandatory. `--config-home` defaults to the explicit
+home's `.config`; it deliberately does not inherit ambient `XDG_CONFIG_HOME` or
+`BACKSCROLL_CONFIG_DIR`. If OpenCode uses a different XDG config root, pass that
+same root explicitly to **both** plan and apply. All three targets are included
+in one approval. No other directory is swept or removed. In particular, old
+`backscroll-doctor`, plugin-managed skills, project overrides, and unsupported
+copies are outside this installer's ownership; inventory and retire them through
+their own owners, with separate approval. This installer is not for Windows.
+
+Neither `install.sh`/`install.ps1` nor `pre-push`/`post-merge` replaces skill
+folders. Downloading a binary does not establish a stable skill source. Git hooks
+still handle their existing binary/input work, but skill replacement is never a
+side effect of a push or merge.
+
+## Inspect, approve, install
+
+Choose an ordinary product clone that you intend to keep. Do not choose a task
+copy or a directory scheduled for cleanup. The installer rejects linked Git
+worktrees, missing or dirty canonical skills, untracked/ignored overlays, skill-tree
+symlinks, and source/destination overlap. An ordinary clone can still be deleted
+by its owner: filesystem inspection cannot prove your retention intent.
+
+Run the read-only inventory from the product repository:
+
+```bash
+python3 scripts/install-skills.py plan \
+  --source-root /absolute/stable/backscroll --home /absolute/destination/home
+```
+
+Inspect the full JSON: source root, canonical path, source commit, tree SHA-256,
+all three exact destination paths, and recursive `before` preimages. The digest
+covers filenames, file contents, modes and lexical symlink targets, not access
+times, ACLs or extended attributes. Backups preserve the original filesystem
+objects by rename rather than copying their contents. No symlink is traversed
+while inventorying a destination. Special files and hard-linked regular files
+are refused rather than incompletely inventoried.
+
+**For a real home, obtain explicit approval for this exact inventory digest.**
+A historical issue digest, a successful fixture test, or permission to implement
+the installer is not rollout permission. Never automatically pipe plan's digest
+into apply. After approval, repeat the same arguments:
+
+```bash
+python3 scripts/install-skills.py apply \
+  --source-root /absolute/stable/backscroll --home /absolute/destination/home \
+  --approve APPROVED_PLAN_SHA256
+```
+
+A changed source commit/content, path, destination type/content/mode, or action
+invalidates approval. Plan writes nothing; an approval mismatch does not even
+create installation state. Apply checks again under a per-home advisory lock,
+records recovery instructions, renames each previous object to a backup, then
+creates the link. Already-correct links are not moved or backed up again; repeated
+installation returns `changed: 0`. Backups and destinations must be on the same
+filesystem. Symlinked destination/state ancestors are refused.
+
+This is a local, single-operator filesystem tool, not a security boundary against
+a hostile process running as the same user. Stop concurrent writers and source
+updates during application/restoration. The lock serializes this installer only;
+it cannot lock your editor or Git. Do not use it on shared/network filesystems.
+
+## Verify and update
+
+Repeat `plan` with the same paths: every target should report `change: false`,
+`before.kind: link`, and `before.target` equal to `source.path`. Inspect both the
+lexical link (`readlink <installed-entry>`) and the resolved `SKILL.md` contents.
+The three entries resolve to the same source, not separately copied versions.
+
+Update the stable clone through your normal reviewed Git workflow. All three
+links then expose the new source without reinstalling. Do not move/delete the
+source while links depend on it. Restart runtimes that cache skills. Local edits
+to that source are immediately visible too; the links are not immutable release
+snapshots. A new `plan` validates the current committed source again.
+
+Runtime checks are distinct from link checks:
+
+- Claude: its [documented personal-skill discovery](https://code.claude.com/docs/en/skills)
+  follows symlinked skill folders. Check `/skills` in a fresh session. The CLI
+  `claude plugin validate <skills-parent> --json` **skips symlink entries** even
+  when it reports success; validate the canonical parent `.claude/skills` as well.
+  Validator success alone is not a session-discovery result.
+- Codex: [user skills](https://developers.openai.com/codex/skills) are discovered
+  under `$HOME/.agents/skills`, including symlinked directories. The app-server
+  `skills/list` response reports the resolved `SKILL.md` path and enabled state.
+- OpenCode: `opencode debug skill --pure` reports available skills, their lexical
+  locations and content. Its [discovery contract](https://opencode.ai/docs/skills/)
+  also scans Claude/Agents-compatible paths; checking only a name can mask a broken
+  OpenCode-specific entry. Verify the returned location and content.
+
+The installed recipe uses cwd inference first, semantic IDs for explicit
+`--project`, and robot `result_N_filepath` / `result_N_content` keys. JSON's
+`source_path` / `snippet` keys are not robot field names.
+
+## Receipts, rollback and restoration
+
+Apply returns `receipt` and `restore_approval`. Keep both. The private directory
+`<home>/.local/state/backscroll/skill-install/<transaction>/` contains an immutable
+`receipt.json`, backups, and append-only `events.jsonl`. The prepared event holds
+the restore digest before the first replacement; install/restore intent and
+completion events are flushed to disk. The receipt records all planned targets,
+so recovery does not rely on the last console line. No automatic backup retention
+or deletion policy is imposed.
+
+An ordinary application error attempts rollback of all changed destinations. If
+rollback cannot safely reconcile a changed destination or backup, it stops and
+preserves the evidence; the error prints the receipt path and restore digest.
+After interruption, inspect the transaction receipt and its prepared event, then
+use the same explicit restoration command:
+
+```bash
+python3 scripts/install-skills.py restore --home /absolute/destination/home \
+  --receipt /absolute/path/to/receipt.json --approve RESTORE_SHA256
+```
+
+Restore validates **every** destination and backup before restoring any. It moves
+backups back without overwriting new operator work, restores originally absent
+entries to absence, and is safe to repeat after interruption or successful
+restoration. A source clone need not still exist for restoration. Empty parent
+directories created by installation may remain. If a destination/backup was edited
+since install, obtain a fresh inventory and operator decision; do not force a
+restore or hand-delete evidence to make it pass.
+
+For uninstall without restoring the previous copies, use the same two-step
+`plan` / `apply` flow with `--action uninstall` on **both** commands. Uninstall
+only removes exact links to the selected source, backs those links up, and refuses
+unowned entries. Its own receipt can restore the links. To recover the older
+copies instead, restore the original installation receipt after reconciling any
+later transactions in reverse order. No command deletes the product source.
+
+## Tests and evidence
+
+```bash
+just test-skills
+# Optional installed-runtime probe, macOS only; blocks network and external writes:
+python3 tests/skill_runtime_probe.py
+```
+
+Tests create all homes, Git sources, databases and backup state under the ignored
+`.local-evidence/` directory. They never replace real installed skills. CI runs
+filesystem and installed-recipe E2E tests on Linux and macOS without requiring
+agent runtimes or credentials. See [issue #62 evidence](eval/skill-installation.md)
+for the versioned native RED, corrected robot oracle, results and runtime limits.

--- a/scripts/install-skills.py
+++ b/scripts/install-skills.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Explicit POSIX Backscroll skill installation. See docs/skill-installation.md.
+
+plan is read-only; apply requires the exact plan digest. All replaced objects are
+renamed into a private transaction directory. Receipts precede mutation and a
+restore operation is safe to repeat after an interrupted install or restore.
+Requires Python 3.9+, Git, and a stable ordinary clone (not a linked worktree).
+"""
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+SKILL = Path(".claude/skills/backscroll")
+STATE = Path(".local/state/backscroll/skill-install")
+
+
+def digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def safe_parents(path):
+    """Never follow a symlinked destination/receipt ancestor."""
+    for parent in reversed(path.parents):
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            raise ValueError(f"unsafe ancestor: {parent}")
+
+
+def absolute(path):
+    result = Path(os.path.abspath(path))
+    safe_parents(result)
+    return result
+
+
+def snapshot(path):
+    """Exact content, mode and lexical links; never traverse links or special files."""
+    try:
+        meta = path.lstat()
+    except FileNotFoundError:
+        return {"kind": "absent"}
+    mode = stat.S_IMODE(meta.st_mode)
+    if stat.S_ISLNK(meta.st_mode):
+        return {"kind": "link", "target": os.readlink(path)}
+    if stat.S_ISREG(meta.st_mode):
+        if meta.st_nlink != 1:
+            raise ValueError(f"hard-linked file not supported: {path}")
+        return {"kind": "file", "mode": mode, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+    if stat.S_ISDIR(meta.st_mode):
+        return {"kind": "directory", "mode": mode,
+                "entries": {child.name: snapshot(child) for child in sorted(path.iterdir())}}
+    raise ValueError(f"special file not supported: {path}")
+
+
+def source_info(root):
+    root = absolute(root)
+    if root.is_symlink() or not (root / ".git").is_dir() or (root / ".git").is_symlink():
+        raise ValueError("source-root must be a stable ordinary clone, not a linked worktree")
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_OPTIONAL_LOCKS"] = "0"  # inventory must not refresh/write the source index
+    command = ["git", "-c", "core.fsmonitor=false", "-C", str(root)]
+
+    def git(*args):
+        return subprocess.check_output([*command, *args], env=env, text=True).strip()
+
+    if Path(git("rev-parse", "--show-toplevel")) != root:
+        raise ValueError("source-root must name the clone root")
+    source = root / SKILL
+    safe_parents(source)
+    tree = snapshot(source)
+    if tree["kind"] != "directory" or not (source / "SKILL.md").is_file():
+        raise ValueError("canonical SKILL.md missing")
+    # Keep distribution entirely product-owned; reject local overlays/links.
+    def check_tree(node):
+        if node["kind"] == "link":
+            raise ValueError("canonical skill tree must not contain symlinks")
+        for child in node.get("entries", {}).values():
+            check_tree(child)
+    check_tree(tree)
+    if git("status", "--porcelain", "--untracked-files=all", "--ignored", "--", str(SKILL)):
+        raise ValueError("canonical skill must be clean and fully tracked")
+    git("ls-files", "--error-unmatch", str(SKILL / "SKILL.md"))
+    commit = git("rev-parse", "HEAD")
+    # status alone can miss assume-unchanged / skip-worktree edits. Compare
+    # committed blob bytes too; never ship a local overlay as a committed source.
+    records = subprocess.check_output([*command, "ls-tree", "-rz", commit, "--", str(SKILL)], env=env)
+    for record in records.split(b"\0"):
+        if not record:
+            continue
+        header, name = record.split(b"\t", 1)
+        mode, kind, oid = header.split()
+        if kind != b"blob" or mode not in (b"100644", b"100755"):
+            raise ValueError("canonical source contains non-file Git entries")
+        content = subprocess.check_output([*command, "cat-file", "blob", oid.decode()], env=env)
+        if (root / os.fsdecode(name)).read_bytes() != content:
+            raise ValueError("canonical skill bytes differ from the source commit")
+    return {"root": str(root), "path": str(source), "commit": commit,
+            "tree_sha256": digest(tree)}
+
+
+def targets(home, config_home):
+    return [home / ".claude/skills/backscroll", home / ".agents/skills/backscroll",
+            config_home / "opencode/skills/backscroll"]
+
+
+def make_plan(root, home, config_home, action):
+    source = source_info(root)
+    destinations = targets(home, config_home)
+    protected = [Path(source["path"]), home / STATE]
+    for i, target in enumerate(destinations):
+        for other in protected + destinations[i + 1:]:
+            if target == other or target in other.parents or other in target.parents:
+                raise ValueError(f"overlapping source, state or destinations: {target}, {other}")
+    if home / STATE == Path(source["root"]) or home / STATE in Path(source["root"]).parents:
+        raise ValueError("source must not live inside installation state")
+    rows = []
+    for target in destinations:
+        safe_parents(target)
+        before = snapshot(target)
+        linked = before == {"kind": "link", "target": source["path"]}
+        if action == "uninstall" and before["kind"] != "absent" and not linked:
+            raise ValueError(f"uninstall refuses an unowned destination: {target}")
+        rows.append({"path": str(target), "before": before,
+                     "change": not linked if action == "install" else linked})
+    plan = {"version": 1, "action": action, "home": str(home), "config_home": str(config_home),
+            "source": source, "targets": rows}
+    return {**plan, "approval": digest(plan)}
+
+
+def private_dir(path):
+    safe_parents(path)
+    if path.is_symlink():
+        raise ValueError(f"unsafe state directory: {path}")
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.stat().st_uid != os.getuid() or stat.S_IMODE(path.stat().st_mode) != 0o700:
+        raise ValueError(f"state directory must be owned by you and mode 0700: {path}")
+
+
+@contextlib.contextmanager
+def locked(home):
+    state = home / STATE
+    private_dir(state)
+    fd = os.open(state / "lock", os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+    try:
+        if os.fstat(fd).st_nlink != 1:
+            raise ValueError("unsafe lock file")
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield state
+    finally:
+        os.close(fd)
+
+
+def append_event(run, event):
+    fd = os.open(run / "events.jsonl", os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "a") as stream:
+        if os.fstat(stream.fileno()).st_nlink != 1:
+            raise ValueError("unsafe event file")
+        stream.write(json.dumps(event, sort_keys=True) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def sync_dir(path):
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def restore_rows(run, receipt):
+    """Validate every preimage first. Preserve all evidence if anything drifted."""
+    plan = receipt["plan"]
+    after = {"kind": "link", "target": plan["source"]["path"]} if plan["action"] == "install" else {"kind": "absent"}
+    pending = []
+    for i, row in enumerate(plan["targets"]):
+        if not row["change"]:
+            continue
+        target = Path(row["path"])
+        safe_parents(target)
+        current = snapshot(target)
+        backup = run / f"backup-{i}"
+        saved = snapshot(backup)
+        before = row["before"]
+        if current == before and saved["kind"] == "absent":
+            continue  # not started, or already restored
+        if current not in (after, {"kind": "absent"}) or saved != before:
+            raise ValueError(f"restore refuses changed destination or backup: {target}")
+        pending.append((target, backup, before))
+    for target, backup, before in pending:
+        append_event(run, {"event": "restore-intent", "path": str(target)})
+        if target.is_symlink():
+            target.unlink()
+        if before["kind"] != "absent":
+            backup.rename(target)
+        sync_dir(target.parent)
+        sync_dir(run)
+        append_event(run, {"event": "restored", "path": str(target)})
+    return len(pending)
+
+
+def apply(root, home, config_home, action, approval):
+    # Check approval before even creating operational state.
+    plan = make_plan(root, home, config_home, action)
+    if approval != plan["approval"]:
+        raise ValueError("approval mismatch; inspect a fresh plan before authorizing")
+    with locked(home) as state:
+        if make_plan(root, home, config_home, action) != plan:
+            raise ValueError("inventory changed before installation")
+        run = state / uuid.uuid4().hex
+        private_dir(run)
+        receipt = {"version": 1, "plan": plan, "run": run.name}
+        restore_approval = digest(receipt)
+        with (run / "receipt.json").open("x") as stream:
+            os.chmod(run / "receipt.json", 0o600)
+            json.dump(receipt, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+        sync_dir(run)
+        sync_dir(state)
+        append_event(run, {"event": "prepared", "restore_approval": restore_approval})
+        changed = 0
+        try:
+            for i, row in enumerate(plan["targets"]):
+                if not row["change"]:
+                    continue
+                target = Path(row["path"])
+                safe_parents(target)
+                if snapshot(target) != row["before"]:
+                    raise ValueError(f"destination changed during installation: {target}")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.parent.stat().st_dev != run.stat().st_dev:
+                    raise ValueError("backup and destination must be on the same filesystem")
+                append_event(run, {"event": "install-intent", "path": str(target)})
+                if row["before"]["kind"] != "absent":
+                    target.rename(run / f"backup-{i}")
+                    sync_dir(run)
+                    sync_dir(target.parent)
+                if action == "install":
+                    target.symlink_to(plan["source"]["path"], target_is_directory=True)
+                sync_dir(target.parent)
+                changed += 1
+                append_event(run, {"event": "installed", "path": str(target)})
+            if source_info(root) != plan["source"]:
+                raise ValueError("canonical source changed during installation")
+        except Exception:
+            print(f"recovery receipt: {run / 'receipt.json'}; restore_approval: {restore_approval}", file=sys.stderr)
+            append_event(run, {"event": "failed", "receipt": str(run / "receipt.json")})
+            restore_rows(run, receipt)
+            raise
+        append_event(run, {"event": "complete", "changed": changed})
+        return {"changed": changed, "receipt": str(run / "receipt.json"), "restore_approval": restore_approval}
+
+
+def restore(home, receipt_path, approval):
+    with locked(home) as state:
+        path = absolute(receipt_path)
+        if path.name != "receipt.json" or path.parent.parent != state or path.is_symlink():
+            raise ValueError("receipt must belong to this home's installation state")
+        private_dir(path.parent)
+        try:
+            receipt = json.loads(path.read_text())
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"unreadable receipt: {path}") from exc
+        if digest(receipt) != approval:
+            raise ValueError("restore approval mismatch")
+        plan = receipt["plan"]
+        if receipt["version"] != 1 or receipt["run"] != path.parent.name or plan["home"] != str(home):
+            raise ValueError("receipt identity mismatch")
+        expected = targets(home, absolute(plan["config_home"]))
+        if [str(p) for p in expected] != [r["path"] for r in plan["targets"]]:
+            raise ValueError("receipt destinations mismatch")
+        count = restore_rows(path.parent, receipt)
+        append_event(path.parent, {"event": "restore-complete", "restored": count})
+        return {"restored": count, "receipt": str(path)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("plan", "apply"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("--source-root", required=True, help="operator-selected stable ordinary product clone")
+        cmd.add_argument("--home", required=True, help="explicit destination home")
+        cmd.add_argument("--config-home", help="OpenCode config root; defaults to HOME/.config, not ambient XDG")
+        cmd.add_argument("--action", choices=("install", "uninstall"), default="install")
+        if name == "apply":
+            cmd.add_argument("--approve", required=True, help="exact approval digest from a freshly inspected plan")
+    cmd = sub.add_parser("restore")
+    cmd.add_argument("--home", required=True)
+    cmd.add_argument("--receipt", required=True)
+    cmd.add_argument("--approve", required=True, help="restore_approval from apply/prepared event")
+    args = parser.parse_args()
+    try:
+        # Canonicalize HOME once (macOS /var is a system symlink); all children
+        # remain lexical and are checked for symlink ancestors before mutation.
+        home = Path(args.home).resolve(strict=True)
+        if not home.is_dir():
+            raise ValueError("home must be an existing directory")
+        if args.command == "restore":
+            result = restore(home, args.receipt, args.approve)
+        else:
+            config = absolute(args.config_home) if args.config_home else home / ".config"
+            root = Path(args.source_root).resolve(strict=True)
+            if args.command == "plan":
+                result = make_plan(root, home, config, args.action)
+            else:
+                result = apply(root, home, config, args.action, args.approve)
+        print(json.dumps(result, indent=2, sort_keys=True))
+    except (OSError, ValueError, KeyError, subprocess.SubprocessError) as exc:
+        print(f"skill installation refused: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skill_install_poc.py
+++ b/tests/skill_install_poc.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Native distribution probe, isolated HOME; no push, network or installed binary.
+
+Build a dev backscroll binary first and pass it as the sole argument. Hook build
+and rootline are stubbed: only the unchanged native skill-distribution path is
+under observation. The retrieval command uses the real dev binary.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(argv, **kwargs):
+    return subprocess.run(argv, check=True, text=True, capture_output=True, **kwargs)
+
+
+def probe(binary):
+    with tempfile.TemporaryDirectory(prefix="skill-poc-", dir=ROOT / ".local-evidence") as tmp:
+        base = Path(tmp)
+        home = base / "home"
+        home.mkdir()
+        config = home / ".config"
+        stub = base / "bin"
+        stub.mkdir()
+        # Do not rebuild/install a release-identity binary or run rootline fix.
+        for name in ("go", "rootline"):
+            path = stub / name
+            path.write_text("#!/bin/sh\nexit 1\n")
+            path.chmod(0o755)
+        env = {**os.environ, "HOME": str(home), "XDG_CONFIG_HOME": str(config),
+               "XDG_DATA_HOME": str(home / ".local/share"), "XDG_CACHE_HOME": str(home / ".cache"),
+               "BACKSCROLL_CONFIG_DIR": str(config), "BACKSCROLL_DATABASE_PATH": str(base / "index.db"),
+               "BACKSCROLL_BIN": str(base / "not-installed"), "TMPDIR": str(base),
+               "PATH": str(stub) + os.pathsep + os.environ["PATH"]}
+        destinations = [home / ".claude/skills/backscroll", home / ".agents/skills/backscroll",
+                        config / "opencode/skills/backscroll"]
+        for dest in destinations:
+            dest.mkdir(parents=True)
+            (dest / "SKILL.md").write_text("STALE --project <cwd-or-inferred>\n")
+            (dest / "local-note").write_text("preserve me\n")
+        native = subprocess.run(["bash", str(ROOT / ".githooks/pre-push")], input="", env=env,
+                                cwd=ROOT, text=True, capture_output=True)
+        observed = [{"target": str(d.relative_to(home)), "link": d.is_symlink(),
+                     "sentinel_retained": (d / "local-note").exists(),
+                     "stale": "STALE" in (d / "SKILL.md").read_text()} for d in destinations]
+        # Isolated declarative input; no raw session inspection or real index.
+        inputs = config / "backscroll/inputs"
+        inputs.mkdir(parents=True, exist_ok=True)
+        for preset in inputs.glob("*.inputs.toml"):
+            preset.unlink()
+        fixture = base / "fixture"
+        fixture.mkdir()
+        document = fixture / "recall.md"
+        document.write_text("# Recall\n\ninstallationoraclecobalt\n")
+        (inputs / "fixture.inputs.toml").write_text(
+            'version = 1\n[[inputs]]\nid = "fixture"\nsource = "memory"\nactive = true\n'
+            '[inputs.discover]\nroots = [' + json.dumps(str(fixture)) + ']\ninclude = ["**/*.md"]\n'
+            '[inputs.decode]\nformat = "markdown_document"\n')
+        search = run([str(binary), "search", "installationoraclecobalt", "--all-projects",
+                      "--robot", "--fields", "minimal", "--max-tokens", "2000"], env=env, cwd=base)
+        fields = dict(line.split("=", 1) for line in search.stdout.splitlines() if "=" in line)
+        assert fields.get("result_0_filepath") == str(document), search.stdout + search.stderr
+        assert "result_0_source_path" not in fields
+        print(json.dumps({"native_hook_exit": native.returncode, "targets": observed,
+                          "robot": search.stdout, "search_stderr": search.stderr}, indent=2))
+
+
+if __name__ == "__main__":
+    probe(Path(sys.argv[1]).resolve())

--- a/tests/skill_runtime_probe.py
+++ b/tests/skill_runtime_probe.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Optional real-runtime discovery probe on macOS, network/file-write sandboxed.
+
+Requires installed Claude Code, Codex and OpenCode. No model invocation or login.
+Not a CI dependency: CI uses the deterministic filesystem/recipe E2E tests.
+"""
+import json
+import os
+import selectors
+import shutil
+import subprocess
+import time
+
+from test_skill_install import SkillInstallTest
+
+
+def rpc(proc, message, expected):
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(json.dumps(message) + "\n")
+    proc.stdin.flush()
+    deadline = time.monotonic() + 30
+    with selectors.DefaultSelector() as selector:
+        selector.register(proc.stdout, selectors.EVENT_READ)
+        while time.monotonic() < deadline:
+            if not selector.select(timeout=max(0, deadline - time.monotonic())):
+                break
+            line = proc.stdout.readline()
+            if not line:
+                break
+            response = json.loads(line)
+            if response.get("id") == expected:
+                if "error" in response:
+                    raise RuntimeError(response)
+                return response["result"]
+    raise RuntimeError(f"no response to {message['method']}")
+
+
+def probe():
+    sandbox = shutil.which("sandbox-exec")
+    if sandbox is None:
+        raise RuntimeError("probe requires macOS sandbox-exec to prohibit network and external writes")
+    binaries = {}
+    for name in ("claude", "codex", "opencode"):
+        binary = shutil.which(name)
+        if binary is None:
+            raise RuntimeError(f"native tool missing: {name}")
+        binaries[name] = binary
+    fixture = SkillInstallTest()
+    fixture.setUp()
+    try:
+        fixture.apply(fixture.plan())
+        cwd = fixture.base / "empty-project"
+        cwd.mkdir()
+        fixture.command(["git", "init", "-q", str(cwd)])
+        home = fixture.home
+        (home / ".codex").mkdir()
+        # Deliberately do not inherit keys, auth stores, plugin directories, or
+        # runtime-specific overrides from the developer's environment.
+        env = {"PATH": os.environ["PATH"], "HOME": str(home), "TMPDIR": str(fixture.base),
+               "XDG_CONFIG_HOME": str(home / ".config"), "XDG_CACHE_HOME": str(home / ".cache"),
+               "XDG_DATA_HOME": str(home / ".local/share"), "XDG_STATE_HOME": str(home / ".local/state"),
+               "CODEX_HOME": str(home / ".codex"), "CLAUDE_CONFIG_DIR": str(home / ".claude"),
+               "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1", "DISABLE_AUTOUPDATER": "1",
+               "OPENCODE_DISABLE_MODELS_FETCH": "1", "OPENCODE_DISABLE_DEFAULT_PLUGINS": "1",
+               "OPENCODE_DISABLE_AUTOUPDATE": "1"}
+        policy = '(version 1)(allow default)(deny network*)(deny file-write*)' + \
+                 '(allow file-write* (subpath ' + json.dumps(str(fixture.base)) + ') (literal "/dev/null"))'
+        prefix = [sandbox, "-p", policy]
+
+        def run(tool, *args):
+            result = subprocess.run(prefix + [binaries[tool], *args], cwd=cwd, env=env,
+                                    text=True, capture_output=True, timeout=40)
+            if result.returncode:
+                raise RuntimeError(f"{tool}: {result.stdout}\n{result.stderr}")
+            return result.stdout
+
+        versions = {name: run(name, "--version").strip() for name in binaries}
+        claude = json.loads(run("claude", "plugin", "validate", str(home / ".claude/skills"), "--json"))
+        claude_target = json.loads(run("claude", "plugin", "validate", str(fixture.skill.parent), "--json"))
+        if not claude_target.get("success"):
+            raise AssertionError(claude_target)
+        opencode = json.loads(run("opencode", "debug", "skill", "--pure"))
+        # isolate the OpenCode-specific destination: without this, its compatible
+        # Claude/Agents scanning could conceal a broken OpenCode symlink.
+        fixture.targets[0].unlink()
+        fixture.targets[1].unlink()
+        opencode_only = json.loads(run("opencode", "debug", "skill", "--pure"))
+        fixture.targets[0].symlink_to(fixture.skill)
+        fixture.targets[1].symlink_to(fixture.skill)
+        log = fixture.base / "codex.stderr"
+        with log.open("w") as stderr:
+            proc = subprocess.Popen(prefix + [binaries["codex"], "app-server", "--stdio"],
+                                    cwd=cwd, env=env, text=True, stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE, stderr=stderr, bufsize=1)
+            try:
+                rpc(proc, {"id": 1, "method": "initialize", "params": {
+                    "clientInfo": {"name": "backscroll-discovery", "version": "1"}}}, 1)
+                assert proc.stdin is not None
+                proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
+                proc.stdin.flush()
+                codex = rpc(proc, {"id": 2, "method": "skills/list", "params": {
+                    "cwds": [str(cwd)], "forceReload": True}}, 2)
+            finally:
+                proc.terminate()
+                proc.wait(timeout=10)
+                if proc.stdin:
+                    proc.stdin.close()
+                if proc.stdout:
+                    proc.stdout.close()
+        for result in (opencode, opencode_only):
+            skills = [entry for entry in result if entry.get("name") == "backscroll"]
+            if len(skills) != 1 or skills[0]["location"] != str(fixture.targets[2] / "SKILL.md"):
+                raise AssertionError(f"OpenCode discovery mismatch: {skills}")
+            if "result_N_filepath" not in skills[0]["content"]:
+                raise AssertionError("OpenCode loaded stale content")
+        skills = [entry for group in codex["data"] for entry in group["skills"] if entry["name"] == "backscroll"]
+        if len(skills) != 1 or skills[0]["path"] != str(fixture.skill / "SKILL.md") or not skills[0]["enabled"]:
+            raise AssertionError(f"Codex discovery mismatch: {skills}")
+        print(json.dumps({"versions": versions, "claude_validation": claude, "claude_target_validation": claude_target,
+                          "opencode_all_destinations": opencode, "opencode_only": opencode_only,
+                          "codex_skills": codex, "codex_stderr": log.read_text()}, indent=2))
+    finally:
+        fixture.doCleanups()
+
+
+if __name__ == "__main__":
+    probe()

--- a/tests/test_skill_install.py
+++ b/tests/test_skill_install.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Filesystem and native-hook E2E regressions; all mutations use a temporary HOME."""
+import importlib.util
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts/install-skills.py"
@@ -15,9 +18,11 @@ INSTALLER = ROOT / "scripts/install-skills.py"
 
 class SkillInstallTest(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory(prefix="skill-test-")
+        evidence = ROOT / ".local-evidence"
+        evidence.mkdir(exist_ok=True)
+        self.tmp = tempfile.TemporaryDirectory(prefix="skill-test-", dir=evidence)
         self.addCleanup(self.tmp.cleanup)
-        self.base = Path(self.tmp.name)
+        self.base = Path(self.tmp.name).resolve()
         self.home = self.base / "home"
         self.home.mkdir()
         self.source = self.base / "stable-product"
@@ -100,6 +105,235 @@ class SkillInstallTest(unittest.TestCase):
         for target in self.targets:
             self.assertFalse(target.is_symlink())
             self.assertEqual((target / "local-note").read_bytes(), b"keep\x00these bytes\n")
+
+    def restore(self, receipt, ok=True):
+        return self.installer("restore", "--home", str(self.home), "--receipt", receipt["receipt"],
+                              "--approve", receipt["restore_approval"], ok=ok)
+
+    def test_plan_is_read_only_and_bound_to_preimage(self):
+        self.seed()
+        plan = self.plan()
+        self.assertFalse((self.home / ".local").exists())
+        (self.targets[1] / "local-note").write_text("changed after inventory")
+        self.assertIn("approval mismatch", self.apply(plan, ok=False)["error"])
+        self.assertFalse((self.home / ".local").exists())
+        self.assertFalse(any(t.is_symlink() for t in self.targets))
+
+    def test_source_change_invalidates_approval(self):
+        plan = self.plan()
+        (self.skill / "SKILL.md").write_text("---\nname: backscroll\ndescription: new\n---\n")
+        self.command(["git", "add", "."], cwd=self.source)
+        self.commit()
+        self.apply(plan, ok=False)
+        self.assertFalse(any(t.exists() for t in self.targets))
+
+    def test_source_updates_propagate_without_reinstallation(self):
+        self.apply(self.plan())
+        with (self.skill / "SKILL.md").open("a") as stream:
+            stream.write("\nupdated source sentinel\n")
+        self.command(["git", "add", "."], cwd=self.source)
+        self.commit()
+        for target in self.targets:
+            self.assertIn("updated source sentinel", (target / "SKILL.md").read_text())
+        self.assertEqual(self.apply(self.plan())["changed"], 0)
+
+    def test_dirty_untracked_ignored_and_linked_sources_rejected(self):
+        for name in ("local-overlay", "ignored-overlay"):
+            with self.subTest(name=name):
+                extra = self.skill / name
+                extra.write_text("not product-owned")
+                if name.startswith("ignored"):
+                    (self.source / ".git/info/exclude").write_text(name + "\n")
+                self.installer("plan", "--source-root", str(self.source), "--home", str(self.home), ok=False)
+                extra.unlink()
+        extra = self.skill / "external"
+        extra.symlink_to(self.base)
+        self.command(["git", "add", "."], cwd=self.source)
+        self.commit()
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.home), ok=False)
+
+    def test_linked_worktree_source_rejected(self):
+        linked = self.base / "disposable"
+        self.command(["git", "worktree", "add", "--detach", str(linked)], cwd=self.source)
+        self.installer("plan", "--source-root", str(linked), "--home", str(self.home), ok=False)
+
+    def test_symlinked_parent_and_source_overlap_rejected(self):
+        external = self.base / "outside"
+        external.mkdir()
+        (self.home / ".agents").symlink_to(external, target_is_directory=True)
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.home), ok=False)
+        self.assertEqual(list(external.iterdir()), [])
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.source), ok=False)
+
+    def test_file_and_broken_link_backups_restore_exactly(self):
+        for target in self.targets:
+            target.parent.mkdir(parents=True)
+        self.targets[0].write_bytes(b"file preimage")
+        self.targets[0].chmod(0o640)
+        self.targets[1].symlink_to("missing-relative-target")
+        receipt = self.apply(self.plan())
+        self.restore(receipt)
+        self.assertEqual(self.targets[0].read_bytes(), b"file preimage")
+        self.assertEqual(self.targets[0].stat().st_mode & 0o777, 0o640)
+        self.assertEqual(os.readlink(self.targets[1]), "missing-relative-target")
+        self.assertFalse(self.targets[2].exists())
+        self.assertEqual(self.restore(receipt)["restored"], 0)
+
+    def test_restore_refuses_destination_or_backup_drift(self):
+        self.seed()
+        receipt = self.apply(self.plan())
+        self.targets[0].unlink()
+        self.targets[0].write_text("operator's new work")
+        self.restore(receipt, ok=False)
+        self.assertEqual(self.targets[0].read_text(), "operator's new work")
+        self.assertTrue(self.targets[1].is_symlink(), "validate all before restoring any")
+        self.targets[0].unlink()
+        self.targets[0].symlink_to(self.skill)
+        backup = Path(receipt["receipt"]).parent / "backup-1/local-note"
+        backup.write_text("backup drift")
+        self.restore(receipt, ok=False)
+        self.assertTrue(all(t.is_symlink() for t in self.targets))
+
+    def test_partial_failure_rolls_back_all_targets(self):
+        self.seed()
+        spec = importlib.util.spec_from_file_location("skill_installer", INSTALLER)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        plan = module.make_plan(self.source, self.home, self.home / ".config", "install")
+        original = Path.symlink_to
+
+        def fail_second(path, *args, **kwargs):
+            if path == self.targets[1]:
+                raise OSError("injected second-destination failure")
+            return original(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "symlink_to", fail_second), self.assertRaisesRegex(OSError, "injected"):
+            module.apply(self.source, self.home, self.home / ".config", "install", plan["approval"])
+        for target in self.targets:
+            self.assertFalse(target.is_symlink())
+            self.assertEqual((target / "local-note").read_bytes(), b"keep\x00these bytes\n")
+        receipt_path = next((self.home / module.STATE).glob("*/receipt.json"))
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(self.restore({"receipt": str(receipt_path), "restore_approval": module.digest(receipt)})["restored"], 0)
+
+    def test_uninstall_only_owned_links_and_restore(self):
+        self.seed()
+        self.installer("plan", "--action", "uninstall", "--source-root", str(self.source),
+                       "--home", str(self.home), ok=False)
+        initial = self.apply(self.plan())
+        removed = self.apply(self.plan("uninstall"))
+        self.assertFalse(any(t.is_symlink() or t.exists() for t in self.targets))
+        self.restore(removed)
+        self.assertTrue(all(t.is_symlink() for t in self.targets))
+        self.restore(initial)
+        self.assertTrue(all((t / "local-note").exists() for t in self.targets))
+
+    def test_receipt_is_append_only_and_restore_token_bound(self):
+        receipt = self.apply(self.plan())
+        path = Path(receipt["receipt"])
+        original = path.read_bytes()
+        events = (path.parent / "events.jsonl").read_bytes()
+        self.restore({**receipt, "restore_approval": "0" * 64}, ok=False)
+        self.restore(receipt)
+        self.assertEqual(path.read_bytes(), original)
+        self.assertTrue((path.parent / "events.jsonl").read_bytes().startswith(events))
+
+    def test_explicit_config_home_and_duplicate_overlap(self):
+        config = self.home / "custom-config"
+        plan = self.installer("plan", "--source-root", str(self.source), "--home", str(self.home),
+                              "--config-home", str(config))
+        self.installer("apply", "--source-root", str(self.source), "--home", str(self.home),
+                       "--config-home", str(config), "--approve", plan["approval"])
+        self.assertTrue((config / "opencode/skills/backscroll").is_symlink())
+        self.assertFalse(self.targets[2].exists())
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.home),
+                       "--config-home", str(self.targets[0]), ok=False)
+
+    @unittest.skipUnless(os.environ.get("BACKSCROLL_TEST_BINARY"), "set BACKSCROLL_TEST_BINARY to a dev build")
+    def test_installed_recipe_retrieves_known_fixture(self):
+        binary = Path(os.environ["BACKSCROLL_TEST_BINARY"]).resolve()
+        self.assertIn("dev", self.command([str(binary), "--version"]).stdout,
+                      "release identities may autoupdate; use a dev build")
+        self.apply(self.plan())
+        cwd = self.base / "application"
+        cwd.mkdir()
+        sessions = self.base / "sessions"
+        sessions.mkdir()
+        document = sessions / "fixture.jsonl"
+        document.write_text(json.dumps({"type": "user", "uuid": "skill-install-fixture", "cwd": str(cwd),
+                            "timestamp": "2026-01-01T00:00:00Z", "message": {"role": "user",
+                            "content": "installationoraclecobalt"}}) + "\n")
+        config = self.home / ".config/backscroll"
+        config.mkdir(parents=True, exist_ok=True)
+        (config / "projects.toml").write_text('[[projects]]\nid = "skill-fixture"\nroots = [' + json.dumps(str(cwd)) + ']\n')
+        self.env["BACKSCROLL_SESSION_DIRS"] = str(sessions)
+        self.env["BACKSCROLL_DATABASE_PATH"] = str(self.base / "index.db")
+        for target in self.targets:
+            with self.subTest(target=target):
+                recipe = (target / "SKILL.md").read_text()
+                line = next(line for line in recipe.splitlines() if line.startswith('backscroll search "QUERY" --robot'))
+                argv = shlex.split(line.replace('"QUERY"', '"installationoraclecobalt"'))
+                result = self.command([str(binary), *argv[1:]], cwd=cwd)
+                fields = dict(line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)
+                self.assertEqual(fields.get("result_0_filepath"), str(document), result.stdout + result.stderr)
+                self.assertNotIn("result_0_source_path", fields)
+
+    def test_skip_worktree_does_not_hide_uncommitted_source(self):
+        self.command(["git", "update-index", "--skip-worktree", ".claude/skills/backscroll/SKILL.md"], cwd=self.source)
+        (self.skill / "SKILL.md").write_text("hidden uncommitted edit")
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.home), ok=False)
+
+    def test_unsafe_state_and_special_preimages_rejected(self):
+        self.seed()
+        plan = self.plan()
+        state = self.home / ".local/state/backscroll/skill-install"
+        state.parent.mkdir(parents=True)
+        outside = self.base / "outside"
+        outside.mkdir()
+        state.symlink_to(outside)
+        self.apply(plan, ok=False)
+        self.assertEqual(list(outside.iterdir()), [])
+        self.assertTrue(all((t / "local-note").exists() for t in self.targets))
+        state.unlink()
+        os.mkfifo(self.targets[0] / "pipe")
+        self.installer("plan", "--source-root", str(self.source), "--home", str(self.home), ok=False)
+
+    def test_restore_after_process_exit_during_second_destination(self):
+        self.seed()
+        # Kill only this fixture subprocess after the second preimage rename.
+        code = '''import importlib.util, os, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("installer", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+root, home = Path(sys.argv[2]), Path(sys.argv[3])
+original = Path.symlink_to
+def stop(path, *args, **kwargs):
+    if ".agents" in path.parts:
+        os._exit(71)
+    return original(path, *args, **kwargs)
+Path.symlink_to = stop
+p = m.make_plan(root, home, home / ".config", "install")
+m.apply(root, home, home / ".config", "install", p["approval"])
+'''
+        result = subprocess.run([sys.executable, "-c", code, str(INSTALLER), str(self.source), str(self.home)],
+                                env=self.env, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 71, result.stderr)
+        self.assertTrue(self.targets[0].is_symlink())
+        self.assertFalse(self.targets[1].exists())
+        receipt_path = next((self.home / ".local/state/backscroll/skill-install").glob("*/receipt.json"))
+        event = json.loads((receipt_path.parent / "events.jsonl").read_text().splitlines()[0])
+        self.restore({"receipt": str(receipt_path), "restore_approval": event["restore_approval"]})
+        self.assertTrue(all((t / "local-note").exists() for t in self.targets))
+
+    def test_installed_recipe_has_observed_robot_keys(self):
+        self.apply(self.plan())
+        for target in self.targets:
+            text = (target / "SKILL.md").read_text()
+            self.assertIn("result_N_filepath", text)
+            self.assertNotIn("result_N_source_path", text)
+            self.assertNotIn("--project <cwd-or-inferred>", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_install.py
+++ b/tests/test_skill_install.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Filesystem and native-hook E2E regressions; all mutations use a temporary HOME."""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts/install-skills.py"
+
+
+class SkillInstallTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="skill-test-")
+        self.addCleanup(self.tmp.cleanup)
+        self.base = Path(self.tmp.name)
+        self.home = self.base / "home"
+        self.home.mkdir()
+        self.source = self.base / "stable-product"
+        self.env = {**os.environ, "HOME": str(self.home), "XDG_CONFIG_HOME": str(self.home / ".config"),
+                    "XDG_DATA_HOME": str(self.home / ".local/share"),
+                    "XDG_CACHE_HOME": str(self.home / ".cache"), "TMPDIR": str(self.base),
+                    "BACKSCROLL_CONFIG_DIR": str(self.home / ".config"),
+                    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1"}
+        for key in list(self.env):
+            if key.startswith("GIT_") and key not in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"):
+                del self.env[key]
+        self.command(["git", "init", "-q", str(self.source)])
+        self.skill = self.source / ".claude/skills/backscroll"
+        shutil.copytree(ROOT / ".claude/skills/backscroll", self.skill)
+        self.command(["git", "add", "."], cwd=self.source)
+        self.commit()
+        self.targets = [self.home / ".claude/skills/backscroll", self.home / ".agents/skills/backscroll",
+                        self.home / ".config/opencode/skills/backscroll"]
+
+    def command(self, argv, **kwargs):
+        return subprocess.run(argv, env=self.env, text=True, capture_output=True, check=True, **kwargs)
+
+    def commit(self):
+        self.command(["git", "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                      "-c", "core.hooksPath=/dev/null", "commit", "-qm", "fixture"], cwd=self.source)
+
+    def installer(self, *args, ok=True):
+        result = subprocess.run([sys.executable, str(INSTALLER), *args], env=self.env,
+                                text=True, capture_output=True)
+        if ok:
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            return json.loads(result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        return {"error": result.stderr}
+
+    def plan(self, action="install"):
+        return self.installer("plan", "--source-root", str(self.source), "--home", str(self.home),
+                              "--action", action)
+
+    def apply(self, plan, ok=True):
+        return self.installer("apply", "--source-root", str(self.source), "--home", str(self.home),
+                              "--action", plan["action"], "--approve", plan["approval"], ok=ok)
+
+    def seed(self):
+        for target in self.targets:
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("STALE --project <cwd-or-inferred>\n")
+            (target / "local-note").write_bytes(b"keep\x00these bytes\n")
+
+    def test_native_hooks_preserve_existing_skills(self):
+        self.seed()
+        stub = self.base / "bin"
+        stub.mkdir()
+        for name in ("go", "rootline"):
+            (stub / name).write_text("#!/bin/sh\nexit 1\n")
+            (stub / name).chmod(0o755)
+        self.env["PATH"] = str(stub) + os.pathsep + os.environ["PATH"]
+        self.env["BACKSCROLL_BIN"] = str(self.base / "uninstalled-binary")
+        for hook in ("pre-push", "post-merge"):
+            self.command(["bash", str(ROOT / ".githooks" / hook)], cwd=ROOT, input="")
+            for target in self.targets:
+                self.assertTrue((target / "local-note").exists(), f"{hook} destroyed {target}")
+                self.assertIn("STALE", (target / "SKILL.md").read_text())
+
+    def test_install_all_targets_backup_repeat_and_restore(self):
+        self.seed()
+        plan = self.plan()
+        for target in self.targets:
+            self.assertFalse(target.is_symlink(), "plan must be read-only")
+        receipt = self.apply(plan)
+        for target in self.targets:
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(os.readlink(target), str(self.skill))
+            self.assertEqual(target.resolve(strict=True), self.skill)
+            self.assertEqual((target / "SKILL.md").read_bytes(), (self.skill / "SKILL.md").read_bytes())
+        self.assertEqual(self.apply(self.plan())["changed"], 0)
+        restored = self.installer("restore", "--home", str(self.home), "--receipt", receipt["receipt"],
+                                  "--approve", receipt["restore_approval"])
+        self.assertEqual(restored["restored"], 3)
+        for target in self.targets:
+            self.assertFalse(target.is_symlink())
+            self.assertEqual((target / "local-note").read_bytes(), b"keep\x00these bytes\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Add an explicit product-owned Backscroll skill installer for Claude, Agents/Codex, and OpenCode. Replace both Git hooks' implicit skill-directory deletion/copy behavior with non-mutating guidance.

## Why

References https://github.com/pablontiv/backscroll/issues/62. The corrected temporary-HOME reproduction confirms that native pre-push destroys a Claude-local sentinel while leaving stale Agents/OpenCode recipes untouched. The real search result uses `result_N_filepath`; the earlier scout's `result_N_source_path` oracle was incorrect.

**This PR implements the mechanism, not a real-home rollout, and intentionally does not close #62.**

## How

- `scripts/install-skills.py`: read-only inventory, source commit/tree and preimage-bound approval, stable ordinary-clone links, preserved filesystem objects, append-only recovery events, repeated install, uninstall and guarded restore. No new Backscroll CLI command or dependency is introduced; the optional repository installer requires Python 3.9+ and Git.
- Remove the two implicit distribution call sites in `pre-push` and `post-merge`. Binary/input installation behavior is unchanged.
- Correct canonical skill guidance to distinguish robot `filepath`/`content` from JSON `source_path`/`snippet`.
- Keep versioned RED in `1eb5b18`, followed by fresh production implementation. `docs/eval/skill-installation.md` records recall, native PoC, test basis and limits; `docs/skill-installation.md` owns installation/update/verification/restoration guidance. ADR0008 remains proposed for review.
- Add 19 isolated filesystem/installed-recipe tests and Linux/macOS CI coverage. Installed-recipe E2E executes the cwd-inferred command read through each destination using a real dev binary and asserts the exact fixture filepath.

### Evidence and limits

- Passed locally: `just check`, `just test`, `just test-skills`, `git diff --check`.
- Sandboxed, network-disabled native probe: Codex `skills/list` reports the enabled user skill at its canonical resolved path; OpenCode discovers its own lexical destination and corrected content even without Claude/Agents-compatible entries.
- Claude's canonical skill passes native validation. Its installed-parent validator explicitly skips symlinks; this is **not** a claim of interactive Claude session discovery. Official documentation supports personal skill symlinks; the actual `/skills` check remains operator rollout work.
- No real installed skill directory was replaced. No release, publication, deployment or merge was performed. Unsupported copies are not automatically removed. Remote CI and exact-final-head independent review remain pending.

## Checklist

- [x] Tests pass (`just test`, `just test-skills`)
- [x] Code is clean (`just check`; no blocking edited-file diagnostics)
- [x] Changes are documented
- [x] Snapshot review is not applicable (Go/Python/shell change, no Rust snapshots)
- [ ] Real-home inventory, digest-bound rollout approval and interactive runtime checks — intentionally outside this PR
