### PR TITLE
feat(search): add opt-in bounded lexical relaxation

### DIFF
--- a/.claude/skills/backscroll/SKILL.md
+++ b/.claude/skills/backscroll/SKILL.md
@@ -92,6 +92,8 @@ Token budget guidance:
 
 If output is truncated, treat it as evidence that more indexed data exists. Refine the query, selected source, or budget instead of abandoning the index.
 
+For explicit lexical term-overload recall, add `--relax` (for example `backscroll search --text '+violet handshake technique adaptation' --relax --robot --fields minimal --max-tokens 2000`); `+term`/quoted phrases stay protected, scope never widens, and relaxed results report `match_stage`/`dropped_terms`—this does not recover missing vocabulary.
+
 ## 5) Query patterns by use case
 
 ### Decision recovery

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Tests use stdlib `testing` + subprocess or direct `run()` invocation. Unit tests
 cmd/backscroll/
 ├── main.go            — entrypoint; run(stdout, stderr, args) for testability
 ├── list.go            — list command (v2: --project, --all-projects, --recent N, --order, --limit, --offset, --json, --robot)
-├── search.go          — search command (v2: --text, --project, --all-projects, --source, --source-path, --after, --before, --role, --content-type, --tag, --fields, --max-tokens, --lexical-only, --similarity-threshold, --json, --robot)
+├── search.go          — search command (v2: --text, --project, --all-projects, --source, --source-path, --after, --before, --role, --content-type, --tag, --fields, --max-tokens, --lexical-only, --relax, --similarity-threshold, --json, --robot)
 ├── patterns.go        — patterns command (v2: --kind commands|failures|templates|sequences|corrections [--pending] [--batch N] [--trend], --project, --all-projects, --tag, --min-support, --min-confidence, --min-length, --max-length, --json, --robot)
 ├── annotate.go        — annotate command (F3b: --uuid --kind --label; validates message existence; upsert semantics)
 ├── recover.go         — recover command (--from, --dry-run; lossless active+stranded database union)
@@ -77,9 +77,11 @@ scripts/
 └── recall-eval/       — isolated legacy/synthetic recall evaluator and cohort reporter
 ```
 
-Ten v2 CLI commands: `list [--project] [--all-projects] [--recent N] [--order timestamp:desc|asc] [--limit] [--offset] [--json] [--robot]`, `search [--text <query>] [--project] [--all-projects] [--source] [--source-path] [--after] [--before] [--role] [--content-type] [--tag] [--limit] [--offset] [--fields minimal|full] [--max-tokens N] [--lexical-only] [--similarity-threshold F] [--json] [--robot]`, `patterns --kind commands|failures|templates|sequences|corrections [--pending] [--batch N] [--project] [--all-projects] [--tag] [--trend] [--after] [--before] [--min-support N] [--min-confidence F] [--min-length N] [--max-length N] [--limit] [--offset] [--json] [--robot]`, `annotate --uuid <u> --kind <k> --label <l> [--path <p> --ordinal <n>]`, `recover --from <path> [--dry-run]`, `status [--json]`, `validate [--json]`, `rebuild`, `purge --before <date>`, `config [--json]`.
+Ten v2 CLI commands: `list [--project] [--all-projects] [--recent N] [--order timestamp:desc|asc] [--limit] [--offset] [--json] [--robot]`, `search [--text <query>] [--project] [--all-projects] [--source] [--source-path] [--after] [--before] [--role] [--content-type] [--tag] [--limit] [--offset] [--fields minimal|full] [--max-tokens N] [--lexical-only] [--relax] [--similarity-threshold F] [--json] [--robot]`, `patterns --kind commands|failures|templates|sequences|corrections [--pending] [--batch N] [--project] [--all-projects] [--tag] [--trend] [--after] [--before] [--min-support N] [--min-confidence F] [--min-length N] [--max-length N] [--limit] [--offset] [--json] [--robot]`, `annotate --uuid <u> --kind <k> --label <l> [--path <p> --ordinal <n>]`, `recover --from <path> [--dry-run]`, `status [--json]`, `validate [--json]`, `rebuild`, `purge --before <date>`, `config [--json]`.
 
 The `SearchEngine` interface is the port; `internal/storage` is the adapter. Database opened lazily. `OpenReadOnly()` provides read-only access for external consumers.
+
+Opt-in lexical term dropping is owned by `internal/storage/relaxation.go`; `docs/search.md#opt-in-lexical-relaxation` defines protected units, the two-unprotected-term floor, fixed scope, provenance and zero-overlap limits. Ordinary search behavior/output must remain unchanged.
 
 ### Core Pipeline
 

--- a/cmd/backscroll/search.go
+++ b/cmd/backscroll/search.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -34,6 +35,7 @@ func newSearchCmd(stdout, stderr io.Writer) *cobra.Command {
 		fields              string
 		maxTokens           int
 		lexicalOnly         bool
+		relax               bool
 		similarityThreshold float64
 		text                string
 	)
@@ -56,10 +58,17 @@ Use --tag to filter sessions by auto-detected tags.
 Use --source-path to filter by indexed source path (exact, SQL LIKE pattern, or * glob).
 Use --json to output as JSON.
 Use --fields to choose machine-readable detail: minimal (default) or full.
-Use --max-tokens to limit output size (approximate token count).`,
+Use --max-tokens to limit output size (approximate token count).
+Use --relax for opt-in lexical recall: after zero rows, drop low-IDF terms while
+keeping at least two unprotected terms. Leading +term and quoted phrases are
+protected. All scope filters remain fixed; no OR or semantic expansion is used.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validateCommandBeforeStartup(cmd, args, cobra.MaximumNArgs(1), func() error {
-				_, _, err := validateAndParseSearchRequest(searchQuery(text, args), fields, contentType, after, before)
+				query := searchQuery(text, args)
+				_, _, err := validateAndParseSearchRequest(query, fields, contentType, after, before)
+				if err == nil && relax {
+					return storage.ValidateRelaxationQuery(query)
+				}
 				return err
 			})
 		},
@@ -71,7 +80,7 @@ Use --max-tokens to limit output size (approximate token count).`,
 			}
 			return runSearch(cmd.Context(), stdout, stderr, startup.Config, query, project, allProjects, jsonFormat, robotFormat,
 				source, sourcePath, after, before, role, limit, offset, contentType, tag,
-				fields, maxTokens, lexicalOnly, similarityThreshold)
+				fields, maxTokens, lexicalOnly, similarityThreshold, relax)
 		},
 	}
 
@@ -91,6 +100,7 @@ Use --max-tokens to limit output size (approximate token count).`,
 	cmd.Flags().StringVar(&fields, "fields", "minimal", "Machine-readable fields to emit: minimal or full")
 	cmd.Flags().IntVar(&maxTokens, "max-tokens", 0, "Max tokens in output (0=unlimited)")
 	cmd.Flags().BoolVar(&lexicalOnly, "lexical-only", false, "Use BM25 only, skip vector search")
+	cmd.Flags().BoolVar(&relax, "relax", false, "After zero lexical rows, drop low-IDF terms within the same scope (+term protects a term)")
 	cmd.Flags().Float64Var(&similarityThreshold, "similarity-threshold", 0.3, "Minimum cosine similarity for vector results (0=no threshold)")
 	cmd.Flags().StringVar(&text, "text", "", "Search text (v2 preferred grammar)")
 
@@ -146,11 +156,16 @@ func runSearch(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config
 	source, sourcePath, after, before, role string,
 	limit, offset int, contentType, tag string,
 	fields string, maxTokens int,
-	lexicalOnly bool, similarityThreshold float64) (retErr error) {
+	lexicalOnly bool, similarityThreshold float64, relax bool) (retErr error) {
 
 	afterTime, beforeTime, err := validateAndParseSearchRequest(query, fields, contentType, after, before)
 	if err != nil {
 		return err
+	}
+	if relax {
+		if err := storage.ValidateRelaxationQuery(query); err != nil {
+			return err
+		}
 	}
 
 	db, diag, err := prepareIndex(ctx, cfg, indexDataRead)
@@ -184,29 +199,40 @@ func runSearch(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config
 		SimilarityThreshold: similarityThreshold,
 	}
 
-	// Execute search — HybridSearch falls back to BM25 when no provider/vectors
-	results, err := db.HybridSearch(query, opts)
+	// The existing path is unchanged unless lexical relaxation is explicit.
+	var results []storage.SearchResult
+	var stages []string
+	if relax {
+		results, stages, err = db.SearchRelaxed(query, opts)
+	} else {
+		results, err = db.HybridSearch(query, opts)
+	}
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
 	}
 
 	if len(results) == 0 {
 		writeSearchHints(stderr, allProjects, contentType == "tool")
+		if relax {
+			fmt.Fprintf(stderr, "relaxation stages tried: %s; stemming/phrase expansion and scope widening skipped\n", strings.Join(stages, ", "))
+		}
 	}
 
 	// Convert storage.SearchResult to models.SearchResult
 	var modelResults []models.SearchResult
 	for i, r := range results {
 		modelResults = append(modelResults, models.SearchResult{
-			Source:      r.Source,
-			Role:        r.Role,
-			Content:     r.Text,
-			FilePath:    r.SourcePath,
-			Timestamp:   r.Timestamp,
-			ProjectPath: r.Project,
-			Score:       r.Score,
-			ContentType: r.ContentType,
-			Rank:        i + 1,
+			Source:       r.Source,
+			Role:         r.Role,
+			Content:      r.Text,
+			FilePath:     r.SourcePath,
+			Timestamp:    r.Timestamp,
+			ProjectPath:  r.Project,
+			Score:        r.Score,
+			ContentType:  r.ContentType,
+			Rank:         i + 1,
+			MatchStage:   r.MatchStage,
+			DroppedTerms: r.DroppedTerms,
 		})
 	}
 
@@ -226,11 +252,13 @@ func runSearch(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config
 			minimal := make([]minimalSearchResult, len(results))
 			for i, r := range results {
 				minimal[i] = minimalSearchResult{
-					SourcePath: r.SourcePath,
-					Snippet:    r.Snippet,
-					Score:      r.Score,
-					Role:       r.Role,
-					Timestamp:  r.Timestamp,
+					SourcePath:   r.SourcePath,
+					Snippet:      r.Snippet,
+					Score:        r.Score,
+					Role:         r.Role,
+					Timestamp:    r.Timestamp,
+					MatchStage:   r.MatchStage,
+					DroppedTerms: r.DroppedTerms,
 				}
 			}
 			if err := formatter.WriteJSON(stdout, minimal); err != nil {
@@ -301,13 +329,13 @@ func searchRobotResultLines(result storage.SearchResult, index int, fields strin
 	}
 
 	if fields == "minimal" {
-		return []string{
+		return searchRobotProvenance([]string{
 			fmt.Sprintf("result_%d_filepath=%s", index, escapeRobotValue(result.SourcePath)),
 			fmt.Sprintf("result_%d_content=%s", index, escapeRobotValue(result.Snippet)),
 			fmt.Sprintf("result_%d_score=%.2f", index, result.Score),
 			fmt.Sprintf("result_%d_role=%s", index, escapeRobotValue(result.Role)),
 			fmt.Sprintf("result_%d_timestamp=%s", index, timestamp),
-		}
+		}, result, index)
 	}
 
 	lines := []string{
@@ -327,7 +355,18 @@ func searchRobotResultLines(result storage.SearchResult, index int, fields strin
 		fmt.Sprintf("result_%d_score=%.2f", index, result.Score),
 		fmt.Sprintf("result_%d_rank=%d", index, index+1),
 	)
-	return lines
+	return searchRobotProvenance(lines, result, index)
+}
+
+func searchRobotProvenance(lines []string, result storage.SearchResult, index int) []string {
+	if result.MatchStage == "" {
+		return lines
+	}
+	dropped, _ := json.Marshal(result.DroppedTerms) // []string is always JSON-encodable
+	return append(lines,
+		fmt.Sprintf("result_%d_match_stage=%s", index, escapeRobotValue(result.MatchStage)),
+		fmt.Sprintf("result_%d_dropped_terms=%s", index, escapeRobotValue(string(dropped))),
+	)
 }
 
 func searchRobotTruncationLines(index, omitted int) []string {
@@ -354,11 +393,13 @@ func flattenRobotGroups(groups [][]string) []string {
 // minimalSearchResult is the reduced JSON payload emitted by --fields=minimal,
 // matching the v0 minimal field set.
 type minimalSearchResult struct {
-	SourcePath string    `json:"source_path"`
-	Snippet    string    `json:"snippet"`
-	Score      float64   `json:"score"`
-	Role       string    `json:"role"`
-	Timestamp  time.Time `json:"timestamp"`
+	SourcePath   string    `json:"source_path"`
+	Snippet      string    `json:"snippet"`
+	Score        float64   `json:"score"`
+	Role         string    `json:"role"`
+	Timestamp    time.Time `json:"timestamp"`
+	MatchStage   string    `json:"match_stage,omitempty"`
+	DroppedTerms []string  `json:"dropped_terms,omitempty"`
 }
 
 // resultsToLines converts SearchResults to string lines for the specified format.
@@ -391,7 +432,11 @@ func resultsToLines(results []models.SearchResult, format picokitoutput.Format) 
 		} else {
 			// Text format: separator + fields
 			lines = append(lines, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-			lines = append(lines, fmt.Sprintf("Rank: %d | Source: %s | Role: %s | Score: %.2f", result.Rank, result.Source, result.Role, result.Score))
+			header := fmt.Sprintf("Rank: %d | Source: %s | Role: %s | Score: %.2f", result.Rank, result.Source, result.Role, result.Score)
+			if result.MatchStage != "" {
+				header += fmt.Sprintf(" | Match stage: %s | Dropped terms: %q", result.MatchStage, result.DroppedTerms)
+			}
+			lines = append(lines, header)
 			lines = append(lines, fmt.Sprintf("Path: %s", result.FilePath))
 			if !result.Timestamp.IsZero() {
 				lines = append(lines, fmt.Sprintf("Time: %s", result.Timestamp.Format("2006-01-02 15:04:05")))

--- a/cmd/backscroll/search.go
+++ b/cmd/backscroll/search.go
@@ -100,7 +100,7 @@ protected. All scope filters remain fixed; no OR or semantic expansion is used.`
 	cmd.Flags().StringVar(&fields, "fields", "minimal", "Machine-readable fields to emit: minimal or full")
 	cmd.Flags().IntVar(&maxTokens, "max-tokens", 0, "Max tokens in output (0=unlimited)")
 	cmd.Flags().BoolVar(&lexicalOnly, "lexical-only", false, "Use BM25 only, skip vector search")
-	cmd.Flags().BoolVar(&relax, "relax", false, "After zero lexical rows, drop low-IDF terms within the same scope (+term protects a term)")
+	cmd.Flags().BoolVar(&relax, "relax", false, "Lexical-only recall: after zero rows, drop low-IDF terms within the same scope (+term protects a term); ignores vector similarity thresholds")
 	cmd.Flags().Float64Var(&similarityThreshold, "similarity-threshold", 0.3, "Minimum cosine similarity for vector results (0=no threshold)")
 	cmd.Flags().StringVar(&text, "text", "", "Search text (v2 preferred grammar)")
 

--- a/cmd/backscroll/search_relaxation_output_test.go
+++ b/cmd/backscroll/search_relaxation_output_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/backscroll/internal/storage"
+	picokitoutput "github.com/pablontiv/picokit/output"
+)
+
+func TestSearchRelaxationBudgetKeepsProvenanceWithEachResult(t *testing.T) {
+	results := []storage.SearchResult{
+		{SourcePath: "/a", Text: "alpha beta", Snippet: "alpha beta", MatchStage: "drop-terms", DroppedTerms: []string{"common", "line\nwith\\slash"}},
+		{SourcePath: "/b", Text: "alpha beta", Snippet: "alpha beta", MatchStage: "drop-terms", DroppedTerms: []string{"common", "line\nwith\\slash"}},
+	}
+	for _, fields := range []string{"minimal", "full"} {
+		for budget := 1; budget < 100; budget++ {
+			lines := searchRobotLines(results, fields, budget)
+			payload := strings.Join(lines, "\n")
+			if picokitoutput.TokenCount(payload) > budget {
+				t.Fatalf("payload exceeds %d tokens: %s", budget, payload)
+			}
+			count := strings.Count(payload, "_filepath=")
+			if count != strings.Count(payload, "_match_stage=drop-terms") || count != strings.Count(payload, "_dropped_terms=") {
+				t.Fatalf("partial result/provenance at budget %d: %s", budget, payload)
+			}
+			if strings.Contains(payload, "line\nwith") {
+				t.Fatalf("unescaped provenance split a robot line: %s", payload)
+			}
+		}
+	}
+}
+
+func TestSearchRelaxationInvalidSyntaxPrecedesStartup(t *testing.T) {
+	testEnv(t)
+	for _, query := range []string{`"unclosed`, "+", `""`, "+ word"} {
+		path := filepath.Join(t.TempDir(), "must-not-exist.db")
+		t.Setenv("BACKSCROLL_DATABASE_PATH", path)
+		out, _, err := runCmd("search", "--text", query, "--relax", "--robot")
+		if err == nil || !strings.Contains(err.Error(), "invalid --relax query") || out != "" {
+			t.Fatalf("expected pure validation failure: %v %q", err, out)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid request created database: %v", err)
+		}
+		if _, err := os.Stat(path + ".startup-sync.lock"); !os.IsNotExist(err) {
+			t.Fatalf("invalid request created startup sidecar: %v", err)
+		}
+	}
+}

--- a/cmd/backscroll/search_relaxation_output_test.go
+++ b/cmd/backscroll/search_relaxation_output_test.go
@@ -35,7 +35,7 @@ func TestSearchRelaxationBudgetKeepsProvenanceWithEachResult(t *testing.T) {
 
 func TestSearchRelaxationInvalidSyntaxPrecedesStartup(t *testing.T) {
 	testEnv(t)
-	for _, query := range []string{`"unclosed`, "+", `""`, "+ word"} {
+	for _, query := range []string{`"unclosed`, "+", `""`, "+ word", "handshake adaptation ...", "violet && handshake", "+...", `"... &&"`} {
 		path := filepath.Join(t.TempDir(), "must-not-exist.db")
 		t.Setenv("BACKSCROLL_DATABASE_PATH", path)
 		out, _, err := runCmd("search", "--text", query, "--relax", "--robot")

--- a/cmd/backscroll/search_relaxation_test.go
+++ b/cmd/backscroll/search_relaxation_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The target is the scout's tracked native recall fixture. The added adaptation
+// term is absent from it but frequent in independent distractor records: a
+// recoverable AND-overload case, unlike the zero-overlap s2/s5 paraphrases.
+// Removing opt-in fallback or dropping rare anchors instead of common terms
+// must lose this target; changing the default must fail the strict control.
+func TestSearchRelaxationRecoverableE2E(t *testing.T) {
+	testEnv(t)
+	sessions := t.TempDir()
+	target := filepath.Join(sessions, "progressive-target.jsonl")
+	fixture, err := os.ReadFile(filepath.Join("..", "..", "docs", "eval", "fixtures", "recall", "progressive-target.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, fixture, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		record := fmt.Sprintf(`{"uuid":"noise-%d","type":"assistant","cwd":"/synthetic/eval","timestamp":"2026-01-01T00:08:00Z","message":{"role":"assistant","content":"The adaptation discussion concerns unrelated component %d."}}`+"\n", i, i)
+		if err := os.WriteFile(filepath.Join(sessions, fmt.Sprintf("noise-%d.jsonl", i)), []byte(record), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inputs := filepath.Join(os.Getenv("BACKSCROLL_CONFIG_DIR"), "backscroll", "inputs")
+	if err := os.MkdirAll(inputs, 0700); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf("version = 1\n[[inputs]]\nid = \"relaxation\"\nsource = \"session\"\nactive = true\n[inputs.discover]\nroots = [%q]\ninclude = [\"**/*.jsonl\"]\n[inputs.decode]\nformat = \"claude\"\n", sessions)
+	if err := os.WriteFile(filepath.Join(inputs, "relaxation.inputs.toml"), []byte(manifest), 0600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"search", "--text", "violet handshake adaptation", "--all-projects", "--lexical-only", "--robot", "--fields", "minimal", "--max-tokens", "200"}
+	strict, stderr, err := runCmd(args...)
+	if err != nil || strict != "" {
+		t.Fatalf("strict must miss target: err=%v stdout=%s stderr=%s", err, strict, stderr)
+	}
+	out, stderr, err := runCmd(append(args, "--relax")...)
+	if err != nil {
+		t.Fatalf("relaxed search: %v stderr=%s", err, stderr)
+	}
+	if !strings.Contains(out, "result_0_filepath="+target+"\n") || strings.Count(out, "_filepath=") != 1 {
+		t.Fatalf("want exact target alone in bounded output, got %s stderr=%s", out, stderr)
+	}
+	if !strings.Contains(out, "result_0_match_stage=drop-terms\n") || !strings.Contains(out, "result_0_dropped_terms=[\"adaptation\"]\n") {
+		t.Fatalf("relaxed target must carry provenance: %s", out)
+	}
+	positive := []string{"search", "--text", "violet handshake", "--all-projects", "--lexical-only", "--robot", "--fields", "minimal"}
+	before, _, err := runCmd(positive...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, _, err := runCmd(append(positive, "--relax")...)
+	if err != nil || after != before {
+		t.Fatalf("an existing strict match must be unchanged, without relaxed provenance: %v\nbefore=%s\nafter=%s", err, before, after)
+	}
+	for _, fields := range []string{"minimal", "full"} {
+		jsonArgs := []string{"search", "--text", "violet handshake adaptation", "--all-projects", "--relax", "--json", "--fields", fields}
+		payload, stderr, err := runCmd(jsonArgs...)
+		if err != nil {
+			t.Fatalf("JSON search: %v %s", err, stderr)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(payload), &rows); err != nil || len(rows) != 1 {
+			t.Fatalf("bad JSON: %v %s", err, payload)
+		}
+		if rows[0]["match_stage"] != "drop-terms" {
+			t.Fatalf("JSON provenance missing: %s", payload)
+		}
+	}
+	human, stderr, err := runCmd("search", "--text", "violet handshake adaptation", "--all-projects", "--relax")
+	if err != nil || !strings.Contains(human, "Match stage: drop-terms | Dropped terms: [\"adaptation\"]") {
+		t.Fatalf("human provenance missing: %v %s %s", err, human, stderr)
+	}
+	for _, filter := range [][]string{{"--project", "nonexistent-project"}, {"--source-path", "/absent-input.jsonl"}, {"--content-type", "tool"}, {"--text", "+adaptation violet handshake"}} {
+		// These invocations deliberately omit --all-projects; explicit project
+		// and input filters must never be broadened to recover the known target.
+		filtered := []string{"search", "--text", "violet handshake adaptation", "--relax", "--robot", "--project", "eval"}
+		payload, stderr, err := runCmd(append(filtered, filter...)...)
+		if err != nil || payload != "" || !strings.Contains(stderr, "relaxation stages tried: strict") {
+			t.Fatalf("protected query/filter escaped: %v stdout=%s stderr=%s", err, payload, stderr)
+		}
+	}
+	for _, format := range [][]string{{}, {"--robot"}, {"--json"}, {"--json", "--fields", "full"}} {
+		base := append([]string{"search", "--text", "violet handshake", "--all-projects", "--lexical-only"}, format...)
+		before, beforeErr, err := runCmd(base...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		after, afterErr, err := runCmd(append(base, "--relax=false")...)
+		if err != nil || after != before || afterErr != beforeErr {
+			t.Fatalf("disabled relaxation changed bytes: %v before=%q after=%q", err, before, after)
+		}
+	}
+	strictAgain, _, err := runCmd(args...)
+	if err != nil || strictAgain != strict {
+		t.Fatalf("opt-in changed subsequent strict output: %v %q", err, strictAgain)
+	}
+}

--- a/docs/adr/0009-relajar-lexico-solo-con-opt-in.md
+++ b/docs/adr/0009-relajar-lexico-solo-con-opt-in.md
@@ -1,0 +1,26 @@
+---
+tipo: adr
+estado: accepted
+fecha: '2026-09-10'
+contexto: 'La conjunción léxica pierde registros ante términos adicionales; las paráfrasis sin vocabulario compartido no se resuelven eliminando términos.'
+decision: 'Ofrecer --relax explícito: búsqueda estricta primero, eliminación por menor IDF tras cero filas, núcleo mínimo de dos términos no protegidos, +término y frases protegidos, filtros invariantes y procedencia obligatoria.'
+alternativas: 'OR global y ampliación de ámbito: descartados por pérdida de precisión; expansión semántica y cambio del valor predeterminado: fuera del alcance; relajar frases protegidas: contradice la intención aprobada.'
+consecuencias: 'La salida predeterminada permanece estable; el modo explícito limita unidades y conserva procedencia dentro del presupuesto; la recuperación depende del solapamiento léxico y de la frecuencia documental.'
+---
+# 0009. Relajar lexico solo con opt in
+
+## Contexto
+
+La conjunción léxica pierde registros ante términos adicionales; las paráfrasis sin vocabulario compartido no se resuelven eliminando términos.
+
+## Decisión
+
+Ofrecer --relax explícito: búsqueda estricta primero, eliminación por menor IDF tras cero filas, núcleo mínimo de dos términos no protegidos, +término y frases protegidos, filtros invariantes y procedencia obligatoria.
+
+## Alternativas descartadas
+
+OR global y ampliación de ámbito: descartados por pérdida de precisión; expansión semántica y cambio del valor predeterminado: fuera del alcance; relajar frases protegidas: contradice la intención aprobada.
+
+## Consecuencias
+
+La salida predeterminada permanece estable; el modo explícito limita unidades y conserva procedencia dentro del presupuesto; la recuperación depende del solapamiento léxico y de la frecuencia documental.

--- a/docs/search.md
+++ b/docs/search.md
@@ -195,7 +195,7 @@ Stemming/phrase-expansion stages are skipped: stemming is already available and 
 
 Pagination and output budgets do not trigger extra relaxation: an exhausted page of an existing stage stays empty, and truncating a result to fit a budget does not cause a new query. Strict matches are never mixed with relaxed matches because fallback runs only after strict eligibility is empty. The existing index candidate limits and ranking are unchanged.
 
-Opt-in syntax supports up to 32 distinct query units. A leading `+` requires a nonempty term; quoted phrases must be nonempty, balanced, and whitespace-delimited. Inside a phrase, double an inner quote (`""`). These validations run before database/startup side effects. FTS operator words such as OR remain literal, not executable query syntax. Marker syntax and phrase parsing apply only with `--relax`.
+Opt-in syntax supports up to 32 distinct query units. A leading `+` requires a nonempty term; quoted phrases must be nonempty, balanced, and whitespace-delimited. Inside a phrase, double an inner quote (`""`). Every unit, including a protected term or phrase, must contain at least one Unicode letter or digit; punctuation-only units such as `...`, `&&`, or `::` are rejected rather than counting toward the core without constraining matches. These validations run before database/startup side effects. FTS operator words such as OR remain literal, not executable query syntax. Marker syntax and phrase parsing apply only with `--relax`.
 
 ### Provenance and limits
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -26,6 +26,7 @@ backscroll search "artifact literal" --source-path "*/session.jsonl" --robot
 | `--fields minimal\|full` | Field set to include (default: `minimal`) |
 | `--max-tokens <N>` | Approximate token limit for total output |
 | `--source-path <PATH_OR_PATTERN>` | Filter a normal text query by indexed `source_path`; exact paths or `*`/SQL `LIKE` patterns |
+| `--relax` | Opt in to bounded lexical term dropping after zero rows; all scope filters stay fixed |
 
 ## Output Formats
 
@@ -52,7 +53,7 @@ Match markers (`>>>` and `<<<` in the raw snippet) are rendered as bold text in 
 ]
 ```
 
-With `--fields full`, the array encodes `models.SearchResult` without JSON tags, so keys are emitted in the current Go field names (PascalCase), not snake_case:
+With `--fields full`, ordinary results encode the existing `models.SearchResult` fields in their Go names (PascalCase):
 
 ```json
 [
@@ -72,7 +73,7 @@ With `--fields full`, the array encodes `models.SearchResult` without JSON tags,
 ]
 ```
 
-Current full-mode fields are exactly: `Source`, `Role`, `Content`, `FilePath`, `Timestamp`, `SessionID`, `ProjectPath`, `Score`, `Tags`, `ContentType`, and `Rank`. `ProjectPath` is a legacy field name; its value is the project identifier (for example `backscroll` or `myproj`), not a filesystem path. Only `--fields minimal` uses the snake_case payload (`source_path`, `snippet`, `score`, `role`, `timestamp`).
+Ordinary full-mode fields are: `Source`, `Role`, `Content`, `FilePath`, `Timestamp`, `SessionID`, `ProjectPath`, `Score`, `Tags`, `ContentType`, and `Rank`. `ProjectPath` is a legacy field name; its value is the project identifier (for example `backscroll` or `myproj`), not a filesystem path. Minimal mode uses the snake_case payload (`source_path`, `snippet`, `score`, `role`, `timestamp`). After opt-in relaxation, both field sets additionally include `match_stage` and `dropped_terms`; ordinary results omit these keys.
 
 ### Robot
 
@@ -168,11 +169,48 @@ every possible echo or repair unrelated BM25 ordering.
 
 User queries are automatically sanitized before being passed to the FTS5 engine:
 
-1. **Dynamic stopword removal** — High-frequency terms (appearing in >50% of documents) are automatically filtered out. These stopwords are computed during `sync` and stored in a `dynamic_stopwords` table, adapting to the corpus without hardcoded dictionaries.
+1. **Dynamic stopword removal** — Sync stores up to 1000 vocabulary terms ordered by document frequency in `dynamic_stopwords`; the implementation does not apply a percentage threshold. The sanitizer compares lowercased input tokens against that Porter-stemmed vocabulary, so raw inflected words may not match their stored stems. This existing behavior is unchanged by the opt-in feature.
 2. **Literal quoting** — Remaining tokens are wrapped in double quotes so special characters (hyphens, colons, parentheses, FTS5 operators like `AND`/`OR`/`NOT`) are treated as literal search terms.
-3. **Prefix matching** — Each token gets an FTS5 prefix `*` suffix, enabling substring matching (e.g., "crash" matches "crashloopbackoff").
+3. **Prefix matching** — Each token gets an FTS5 prefix `*` suffix (e.g., "crash" matches "crashloopbackoff"); this is not arbitrary interior-substring matching.
 
 If all tokens in a query are stopwords, the original query is used unfiltered as a fallback. The FTS5 tokenizer (`porter unicode61`) provides stemming on top of these features.
+
+## Opt-in lexical relaxation
+
+Ordinary searches, including `--relax=false`, retain the existing behavior and output. `--relax` is a lexical-only option, not a new default and not semantic search:
+
+```bash
+backscroll search --text 'violet handshake adaptation' --relax --robot --fields minimal --max-tokens 2000
+backscroll search --text '+violet handshake technique adaptation' --relax --project example
+backscroll search --text '"violet handshake" quartz marker adaptation' --relax --source-path '*/session.jsonl'
+```
+
+The deterministic sequence is:
+
+1. Run strict AND search. Unmarked queries keep the existing sanitizer, ranking and snippets. Leading `+term` marks a term that cannot be dropped; quoted spans are protected phrase units. For queries containing these protected units, strict matching keeps every unit without dynamic stopword removal. Quotes preserve FTS phrase order; ordinary unquoted terms retain Porter stemming/prefix matching (trigram matching for tools).
+2. Only if that stage has zero eligible rows, drop one **unprotected** term at a time, lowest IDF first. For a fixed corpus, this is highest document frequency first. Frequencies are counted with the actual tokenizer's MATCH expression over the applicable index(es), globally rather than within the result scope; equal frequencies drop in original query order. Zero-frequency terms have highest IDF and are not specially discarded. Each retry still requires every retained unit, bypassing dynamic stopwords so the retained core cannot silently disappear.
+3. Stop at the first stage with results, or before fewer than **two distinct unprotected terms** remain. Protected terms are additional to that floor. Case-insensitive repeated spellings count once, and a keep marker on any occurrence protects that unit. Queries with at most two unprotected terms perform strict search only. There is no single-term/empty fallback and no global OR.
+
+Stemming/phrase-expansion stages are skipped: stemming is already available and protected phrases must not weaken. Scope widening is always skipped. Project (including cwd-inferred project), source, source-path, content-type, role, dates, and tags are retained at every stage. Tool searches remain on their trigram index even when relaxation is explicitly requested. Existing unfiltered echo exclusion and cross-index RRF still apply.
+
+Pagination and output budgets do not trigger extra relaxation: an exhausted page of an existing stage stays empty, and truncating a result to fit a budget does not cause a new query. Strict matches are never mixed with relaxed matches because fallback runs only after strict eligibility is empty. The existing index candidate limits and ranking are unchanged.
+
+Opt-in syntax supports up to 32 distinct query units. A leading `+` requires a nonempty term; quoted phrases must be nonempty, balanced, and whitespace-delimited. Inside a phrase, double an inner quote (`""`). These validations run before database/startup side effects. FTS operator words such as OR remain literal, not executable query syntax. Marker syntax and phrase parsing apply only with `--relax`.
+
+### Provenance and limits
+
+Every relaxed result carries its stage and the cumulative dropped terms. Robot mode adds these lines to the same budgeted result group (minimal and full):
+
+```text
+result_0_match_stage=drop-terms
+result_0_dropped_terms=["adaptation"]
+```
+
+`dropped_terms` is a JSON string array encoded as a robot string: undo robot backslash/CR/LF escaping before JSON decoding. Human output includes `Match stage: drop-terms | Dropped terms: ["adaptation"]` in the result header. JSON adds optional snake_case `match_stage` and `dropped_terms` keys to both existing projections. Strict results have no extra result fields. An empty result page reports stages tried on **stderr**, for example `strict, drop-terms/1`; stdout retains its normal empty machine-readable shape. Skipped expansion/widening stages are identified as skipped, not as executed searches.
+
+This addresses **recoverable term overload**, not vocabulary invention. In the native regression, the target contains `violet handshake`, while unrelated records make `adaptation` a common term; strict search misses and dropping that term recovers the target. In contrast, the existing synthetic `s2_conversational_paraphrase` and `s5_progressive_refinement` targets share no surviving content terms with their original queries. The refinement `violet handshake` adds new vocabulary; this feature does not promise to recover those zero-overlap cases. An absent, high-IDF extra term can also prevent recovery at the two-term floor. No production p95 or broad semantic-recall gain is claimed from the small fixture corpus.
+
+Regression owners: `cmd/backscroll/search_relaxation_test.go` (native input-to-output recovery and unchanged strict controls), `cmd/backscroll/search_relaxation_output_test.go` (budgeted provenance and early validation), and `internal/storage/relaxation_test.go` (IDF order, protected core, scope and paging).
 
 ## Exit Codes
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -7,17 +7,19 @@ import (
 
 // SearchResult represents a single search result.
 type SearchResult struct {
-	Source      string // "session", "plan", "ke", "decision", etc.
-	Role        string // "user", "assistant"
-	Content     string // text content (possibly snippet)
-	FilePath    string // path to original file
-	Timestamp   time.Time
-	SessionID   string
-	ProjectPath string
-	Score       float64
-	Tags        []string
-	ContentType string // "text", "code", "tool"
-	Rank        int    // 1-based rank in results
+	Source       string // "session", "plan", "ke", "decision", etc.
+	Role         string // "user", "assistant"
+	Content      string // text content (possibly snippet)
+	FilePath     string // path to original file
+	Timestamp    time.Time
+	SessionID    string
+	ProjectPath  string
+	Score        float64
+	Tags         []string
+	ContentType  string   // "text", "code", "tool"
+	Rank         int      // 1-based rank in results
+	MatchStage   string   `json:"match_stage,omitempty"` // present only after opt-in term dropping
+	DroppedTerms []string `json:"dropped_terms,omitempty"`
 }
 
 // ParsedFile represents a parsed session or plan file.

--- a/internal/storage/relaxation.go
+++ b/internal/storage/relaxation.go
@@ -61,6 +61,11 @@ func parseRecallTerms(query string) ([]recallTerm, error) {
 		if strings.TrimSpace(term.text) == "" {
 			return nil, fmt.Errorf("invalid --relax query: empty phrase or keep-term")
 		}
+		// FTS can ignore punctuation-only units inside AND expressions. They
+		// must not count toward the core while adding no search constraint.
+		if !strings.ContainsFunc(term.text, func(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }) {
+			return nil, fmt.Errorf("invalid --relax query: unit %q has no searchable characters", term.text)
+		}
 		// Repeated spellings are one unit, not a way around the two-term floor.
 		duplicate := false
 		for i := range terms {

--- a/internal/storage/relaxation.go
+++ b/internal/storage/relaxation.go
@@ -1,0 +1,210 @@
+package storage
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/pablontiv/backscroll/internal/models"
+)
+
+type recallTerm struct {
+	text      string
+	protected bool
+	phrase    bool
+}
+
+// ValidateRelaxationQuery validates opt-in syntax before startup side effects.
+// Ordinary search deliberately keeps its existing literal-token grammar.
+func ValidateRelaxationQuery(query string) error {
+	_, err := parseRecallTerms(query)
+	return err
+}
+
+func parseRecallTerms(query string) ([]recallTerm, error) {
+	var terms []recallTerm
+	for rest := strings.TrimSpace(query); rest != ""; rest = strings.TrimSpace(rest) {
+		term := recallTerm{}
+		if strings.HasPrefix(rest, "+") {
+			term.protected = true
+			rest = rest[1:]
+		}
+		if strings.HasPrefix(rest, `"`) {
+			term.phrase, term.protected = true, true
+			rest = rest[1:]
+			var text strings.Builder
+			closed := false
+			for len(rest) > 0 {
+				if strings.HasPrefix(rest, `""`) {
+					text.WriteByte('"')
+					rest = rest[2:]
+				} else if rest[0] == '"' {
+					rest, closed = rest[1:], true
+					break
+				} else {
+					text.WriteByte(rest[0])
+					rest = rest[1:]
+				}
+			}
+			if !closed || (rest != "" && !unicode.IsSpace([]rune(rest)[0])) {
+				return nil, fmt.Errorf("invalid --relax query: quoted phrases must be closed and whitespace-delimited")
+			}
+			term.text = text.String()
+		} else {
+			end := strings.IndexFunc(rest, unicode.IsSpace)
+			if end < 0 {
+				end = len(rest)
+			}
+			term.text, rest = rest[:end], rest[end:]
+		}
+		if strings.TrimSpace(term.text) == "" {
+			return nil, fmt.Errorf("invalid --relax query: empty phrase or keep-term")
+		}
+		// Repeated spellings are one unit, not a way around the two-term floor.
+		duplicate := false
+		for i := range terms {
+			if strings.EqualFold(terms[i].text, term.text) && terms[i].phrase == term.phrase {
+				terms[i].protected = terms[i].protected || term.protected
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			terms = append(terms, term)
+		}
+		if len(terms) > 32 {
+			return nil, fmt.Errorf("invalid --relax query: at most 32 distinct query units are supported")
+		}
+	}
+	if len(terms) == 0 {
+		return nil, fmt.Errorf("invalid --relax query: at least one term is required")
+	}
+	return terms, nil
+}
+
+func recallExpression(terms []recallTerm, table string) string {
+	parts := make([]string, len(terms))
+	for i, term := range terms {
+		parts[i] = `"` + strings.ReplaceAll(term.text, `"`, `""`) + `"`
+		if table != "tool_fts" && !term.phrase {
+			parts[i] += "*"
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// SearchRelaxed performs bounded, opt-in lexical recall. Each stage keeps all
+// filters and requires every remaining unit. Unmarked strict queries use the
+// existing sanitizer. Protected queries and drop stages bypass stopwords so
+// protected terms and the retained core cannot vanish.
+// Stemming/prefix expansion is already supplied by FTS; scope widening is never
+// permitted. Only lowest-IDF term dropping is applicable after a zero-row stage.
+func (d *Database) SearchRelaxed(query string, opts models.SearchOptions) ([]SearchResult, []string, error) {
+	terms, err := parseRecallTerms(query)
+	if err != nil {
+		return nil, nil, err
+	}
+	stages := []string{"strict"}
+	strictQuery := query
+	for _, term := range terms {
+		if term.protected {
+			strictQuery = "" // protected units must bypass stopword removal
+			break
+		}
+	}
+	results, exists, err := d.recallStage(terms, opts, strictQuery)
+	if err != nil || exists {
+		return results, stages, err
+	}
+
+	// For a fixed corpus, IDF is monotone decreasing in document frequency.
+	// Counting actual MATCH documents respects stemming, prefix and trigram
+	// semantics rather than comparing raw words to Porter-stemmed vocab rows.
+	type candidate struct {
+		index int
+		docs  int
+	}
+	var candidates []candidate
+	for i, term := range terms {
+		if !term.protected {
+			candidates = append(candidates, candidate{index: i})
+		}
+	}
+	if len(candidates) <= 2 {
+		return results, stages, nil
+	}
+	for i := range candidates {
+		docs, err := d.recallFrequency(terms[candidates[i].index], opts.ContentType)
+		if err != nil {
+			return nil, stages, err
+		}
+		candidates[i].docs = docs
+	}
+	// Equal IDF drops in original query order, not map or database row order.
+	sort.SliceStable(candidates, func(i, j int) bool { return candidates[i].docs > candidates[j].docs })
+	dropped := make([]string, 0, len(candidates)-2)
+	removed := make(map[int]bool)
+	for _, candidate := range candidates[:len(candidates)-2] {
+		removed[candidate.index] = true
+		dropped = append(dropped, terms[candidate.index].text)
+		var remaining []recallTerm
+		for i, term := range terms {
+			if !removed[i] {
+				remaining = append(remaining, term)
+			}
+		}
+		stages = append(stages, fmt.Sprintf("drop-terms/%d", len(dropped)))
+		results, exists, err = d.recallStage(remaining, opts, "")
+		if err != nil {
+			return nil, stages, err
+		}
+		if exists {
+			for i := range results {
+				results[i].MatchStage = "drop-terms"
+				results[i].DroppedTerms = append([]string(nil), dropped...)
+			}
+			return results, stages, nil
+		}
+	}
+	return results, stages, nil
+}
+
+func (d *Database) recallStage(terms []recallTerm, opts models.SearchOptions, strictQuery string) ([]SearchResult, bool, error) {
+	search := func(table string, page models.SearchOptions) ([]SearchResult, error) {
+		if strictQuery != "" {
+			return d.searchTable(table, strictQuery, page)
+		}
+		return d.searchTableQuery(table, recallExpression(terms, table), page)
+	}
+	results, err := searchTables(opts, search)
+	if err != nil || len(results) > 0 || opts.Offset <= 0 {
+		return results, len(results) > 0, err
+	}
+	// An exhausted page is not a zero-result query. Check before pagination;
+	// do not widen a successful earlier stage to fill a later empty page.
+	opts.Offset, opts.Limit = 0, 1
+	first, err := searchTables(opts, search)
+	return results, len(first) > 0, err
+}
+
+func (d *Database) recallFrequency(term recallTerm, contentType string) (int, error) {
+	tables := []string{"messages_fts"}
+	if contentType == "tool" {
+		tables = []string{"tool_fts"}
+	} else if contentType == "" {
+		tables = append(tables, "tool_fts")
+	}
+	var selects []string
+	var args []any
+	for _, table := range tables {
+		selects = append(selects, "SELECT rowid FROM "+table+" WHERE "+table+" MATCH ?")
+		args = append(args, recallExpression([]recallTerm{term}, table))
+	}
+	var count int
+	err := d.db.QueryRow("SELECT COUNT(*) FROM ("+strings.Join(selects, " UNION ")+")", args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("measure relaxation term frequency: %w", err)
+	}
+	return count, nil
+}

--- a/internal/storage/relaxation_test.go
+++ b/internal/storage/relaxation_test.go
@@ -30,6 +30,12 @@ func relaxationDB(t *testing.T) *Database {
 
 func TestRelaxationStagesAndProtectedCore(t *testing.T) {
 	db := relaxationDB(t)
+	t.Run("punctuation cannot satisfy the two-term floor", func(t *testing.T) {
+		results, stages, err := db.SearchRelaxed("handshake adaptation ...", models.SearchOptions{SourcePath: "/target.jsonl", ContentType: "text", Limit: 5})
+		if err == nil || !strings.Contains(err.Error(), "has no searchable characters") || len(results) != 0 || len(stages) != 0 {
+			t.Fatalf("punctuation must be rejected before any stage, not allow single-term recall: err=%v stages=%v results=%+v", err, stages, results)
+		}
+	})
 	for _, tc := range []struct {
 		query string
 		want  bool
@@ -123,9 +129,14 @@ func TestRelaxationToolFilterAndPagination(t *testing.T) {
 }
 
 func TestRelaxationValidationAndLiterals(t *testing.T) {
-	for _, query := range []string{"", "  ", "+", "+ term", `""`, `"unclosed`, `"phrase"suffix`, strings.Repeat("word ", 33) + "+"} {
+	for _, query := range []string{"", "  ", "+", "+ term", `""`, `"unclosed`, `"phrase"suffix`, strings.Repeat("word ", 33) + "+", "...", "&&", "->", "--", "::", "||", "+...", `"... &&"`, "✨"} {
 		if err := ValidateRelaxationQuery(query); err == nil {
 			t.Errorf("expected invalid query %q", query)
+		}
+	}
+	for _, query := range []string{"a", "7", "é", "東京", "١", "+東京", "--dry-run", "/tmp/a-b", "foo::bar", `"東京 7"`} {
+		if err := ValidateRelaxationQuery(query); err != nil {
+			t.Errorf("letter/digit-bearing unit rejected %q: %v", query, err)
 		}
 	}
 	var long []string

--- a/internal/storage/relaxation_test.go
+++ b/internal/storage/relaxation_test.go
@@ -1,0 +1,173 @@
+package storage
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pablontiv/backscroll/internal/models"
+)
+
+func relaxationDB(t *testing.T) *Database {
+	t.Helper()
+	db, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+	files := []IndexedFile{
+		{SourcePath: "/target.jsonl", Source: "session", Project: "alpha", Hash: "target", Tags: []string{"testing"}, Messages: []IndexedMessage{{Ordinal: 0, UUID: "target", Role: "assistant", ContentType: "text", Text: "violet handshake quartz marker", Timestamp: "2026-01-01T00:00:00Z"}}},
+		{SourcePath: "/reverse.jsonl", Source: "session", Project: "beta", Hash: "reverse", Messages: []IndexedMessage{{Ordinal: 0, UUID: "reverse", Role: "user", ContentType: "text", Text: "handshake violet quartz marker", Timestamp: "2026-01-01T00:00:00Z"}}},
+		{SourcePath: "/tool.jsonl", Source: "session", Project: "alpha", Hash: "tool", Messages: []IndexedMessage{{Ordinal: 0, UUID: "tool", Role: "tool", ContentType: "tool", Text: "violet handshake quartz marker", Timestamp: "2026-01-01T00:00:00Z"}}},
+	}
+	for i := 0; i < 4; i++ {
+		files = append(files, IndexedFile{SourcePath: fmt.Sprintf("/noise-%d.jsonl", i), Source: "session", Project: "alpha", Hash: "noise", Messages: []IndexedMessage{{Ordinal: 0, UUID: fmt.Sprintf("noise-%d", i), Role: "assistant", ContentType: "text", Text: "adaptation rollout distractor", Timestamp: "2026-01-01T00:00:00Z"}}})
+	}
+	if err := db.SyncFiles(files); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestRelaxationStagesAndProtectedCore(t *testing.T) {
+	db := relaxationDB(t)
+	for _, tc := range []struct {
+		query string
+		want  bool
+		drops []string
+		tries []string
+	}{
+		{"violet handshake adaptation", true, []string{"adaptation"}, []string{"strict", "drop-terms/1"}},
+		{"rollout adaptation violet handshake", true, []string{"rollout", "adaptation"}, []string{"strict", "drop-terms/1", "drop-terms/2"}},
+		{"+adaptation rollout violet handshake", false, nil, []string{"strict", "drop-terms/1"}},
+		{"violet nonexistent", false, nil, []string{"strict"}},
+		{"violet violet nonexistent", false, nil, []string{"strict"}},
+		{"violet Violet nonexistent", false, nil, []string{"strict"}},
+		{"+violet +handshake", true, nil, []string{"strict"}},
+		{`"violet handshake" quartz marker adaptation`, true, []string{"adaptation"}, []string{"strict", "drop-terms/1"}},
+		{`"handshake violet" quartz marker adaptation`, false, nil, []string{"strict", "drop-terms/1"}},
+		{"+missing violet handshake adaptation", false, nil, []string{"strict", "drop-terms/1"}},
+		{"remembered connector survive restarts", false, nil, []string{"strict", "drop-terms/1", "drop-terms/2"}},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			results, stages, err := db.SearchRelaxed(tc.query, models.SearchOptions{SourcePath: "/target.jsonl", ContentType: "text", Limit: 5})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (len(results) == 1) != tc.want || len(results) > 1 {
+				t.Fatalf("want target=%t, got %#v", tc.want, results)
+			}
+			if !reflect.DeepEqual(stages, tc.tries) {
+				t.Fatalf("stages=%v want=%v", stages, tc.tries)
+			}
+			if tc.want {
+				if !reflect.DeepEqual(results[0].DroppedTerms, tc.drops) {
+					t.Fatalf("drops=%v want=%v", results[0].DroppedTerms, tc.drops)
+				}
+				if (results[0].MatchStage == "drop-terms") != (len(tc.drops) > 0) {
+					t.Fatalf("bad provenance: %#v", results[0])
+				}
+			}
+		})
+	}
+}
+
+func TestRelaxationPreservesEveryFilter(t *testing.T) {
+	db := relaxationDB(t)
+	after := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	for _, opts := range []models.SearchOptions{
+		{Project: "missing"}, {SourcePath: "/missing.jsonl"}, {Source: "memory"},
+		{Role: "system"}, {ContentType: "reasoning"}, {Tag: "absent"},
+		{After: &after}, {Before: &before},
+		{Project: "beta", Role: "assistant"}, {SourcePath: "/target.jsonl", ContentType: "tool"},
+	} {
+		results, _, err := db.SearchRelaxed("violet handshake adaptation", opts)
+		if err != nil || len(results) != 0 {
+			t.Fatalf("filter escaped: opts=%+v err=%v results=%+v", opts, err, results)
+		}
+	}
+	results, _, err := db.SearchRelaxed("violet handshake adaptation", models.SearchOptions{Project: "alpha", ContentType: "text", Role: "assistant", Tag: "testing", Source: "session", SourcePath: "/target*"})
+	if err != nil || len(results) != 1 || results[0].SourcePath != "/target.jsonl" {
+		t.Fatalf("matching filters lost target: %v %+v", err, results)
+	}
+}
+
+func TestRelaxationToolFilterAndPagination(t *testing.T) {
+	db := relaxationDB(t)
+	// Tool IDF is measured only on the trigram stream. Add frequent tool noise
+	// so adaptation, not the rare two-term core, is the term that can be dropped.
+	var files []IndexedFile
+	for i := 0; i < 3; i++ {
+		files = append(files, IndexedFile{SourcePath: fmt.Sprintf("/tool-noise-%d.jsonl", i), Source: "session", Hash: "noise", Messages: []IndexedMessage{{Ordinal: 0, UUID: fmt.Sprintf("tool-noise-%d", i), Role: "tool", ContentType: "tool", Text: "adaptation rollout distractor"}}})
+	}
+	if err := db.SyncFiles(files); err != nil {
+		t.Fatal(err)
+	}
+	results, _, err := db.SearchRelaxed("violet handshake adaptation", models.SearchOptions{ContentType: "tool"})
+	if err != nil || len(results) != 1 || results[0].SourcePath != "/tool.jsonl" {
+		t.Fatalf("tool-only relaxation: %v %+v", err, results)
+	}
+	for _, query := range []string{"violet handshake", "violet handshake adaptation"} {
+		results, stages, err := db.SearchRelaxed(query, models.SearchOptions{SourcePath: "/target.jsonl", Offset: 1, Limit: 1})
+		if err != nil || len(results) != 0 {
+			t.Fatalf("exhausted page should stay empty: %v %+v", err, results)
+		}
+		wantStages := 1
+		if strings.HasSuffix(query, "adaptation") {
+			wantStages = 2
+		}
+		if len(stages) != wantStages {
+			t.Fatalf("pagination triggered extra relaxation: %v", stages)
+		}
+	}
+}
+
+func TestRelaxationValidationAndLiterals(t *testing.T) {
+	for _, query := range []string{"", "  ", "+", "+ term", `""`, `"unclosed`, `"phrase"suffix`, strings.Repeat("word ", 33) + "+"} {
+		if err := ValidateRelaxationQuery(query); err == nil {
+			t.Errorf("expected invalid query %q", query)
+		}
+	}
+	var long []string
+	for i := 0; i < 33; i++ {
+		long = append(long, fmt.Sprintf("term%d", i))
+	}
+	if err := ValidateRelaxationQuery(strings.Join(long, " ")); err == nil {
+		t.Fatal("unbounded query accepted")
+	}
+	terms, err := parseRecallTerms(`+violet Violet "handshake quartz" "a ""quote""" OR /tmp/a-b --flag`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(terms) != 6 || !terms[0].protected || !terms[1].phrase {
+		t.Fatalf("deduplication/protection lost: %+v", terms)
+	}
+	want := `"violet"* "handshake quartz" "a ""quote""" "OR"* "/tmp/a-b"* "--flag"*`
+	if got := recallExpression(terms, "messages_fts"); got != want {
+		t.Fatalf("literal query=%s want=%s", got, want)
+	}
+	if got := recallExpression(terms[:1], "tool_fts"); got != `"violet"` {
+		t.Fatalf("trigram query=%s", got)
+	}
+	// A protected duplicate later in a query must protect the earlier unit.
+	terms, err = parseRecallTerms("violet +VIOLET")
+	if err != nil || len(terms) != 1 || !terms[0].protected {
+		t.Fatalf("later keep marker lost: %+v %v", terms, err)
+	}
+}
+
+func TestRelaxationErrorsAreNotZeroResultFallbacks(t *testing.T) {
+	db := relaxationDB(t)
+	if _, _, err := db.SearchRelaxed(`"unclosed`, models.SearchOptions{}); err == nil {
+		t.Fatal("invalid direct query accepted")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := db.SearchRelaxed("violet handshake adaptation", models.SearchOptions{}); err == nil {
+		t.Fatal("database failure treated as a retrieval miss")
+	}
+	if _, err := db.recallFrequency(recallTerm{text: "violet"}, "text"); err == nil {
+		t.Fatal("frequency failure ignored")
+	}
+}

--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -12,47 +12,55 @@ import (
 
 // SearchResult represents a single search result.
 type SearchResult struct {
-	ID          int
-	Source      string
-	SourcePath  string
-	Ordinal     int
-	Role        string
-	Text        string
-	Snippet     string
-	Score       float64
-	Timestamp   time.Time
-	UUID        string
-	Project     string
-	ContentType string
-	SearchEcho  bool `json:"-"` // persisted call/result provenance; not a public output field
+	ID           int
+	Source       string
+	SourcePath   string
+	Ordinal      int
+	Role         string
+	Text         string
+	Snippet      string
+	Score        float64
+	Timestamp    time.Time
+	UUID         string
+	Project      string
+	ContentType  string
+	SearchEcho   bool `json:"-"` // persisted call/result provenance; not a public output field
+	MatchStage   string
+	DroppedTerms []string
 }
 
 // Search performs a hybrid search (BM25 + optional vector) on the indexed content.
 // It applies all filters and returns results ranked by BM25 score.
 // When ContentType is empty, it queries both FTS tables and merges via RRF.
 func (d *Database) Search(query string, opts models.SearchOptions) ([]SearchResult, error) {
-	switch opts.ContentType {
-	case "tool":
-		return d.searchTable("tool_fts", query, opts)
-	case "text", "code":
-		return d.searchTable("messages_fts", query, opts)
-	case "":
-		// Unfiltered search: query both tables and merge via RRF
-		// External-content FTS rebuilds may expose tool rows in either index.
-		// Apply the same narrow echo policy to both unfiltered candidate streams.
-		prose, err := d.searchCandidatesWithoutDirectEchoes("messages_fts", query, withoutPaging(opts))
-		if err != nil {
-			return nil, err
-		}
-		tool, err := d.searchCandidatesWithoutDirectEchoes("tool_fts", query, withoutPaging(opts))
-		if err != nil {
-			return nil, err
-		}
-		merged := mergeRRF(prose, tool)
-		return paginate(merged, opts.Limit, opts.Offset), nil
-	default:
-		return d.searchTable("messages_fts", query, opts)
+	return searchTables(opts, func(table string, page models.SearchOptions) ([]SearchResult, error) {
+		return d.searchTable(table, query, page)
+	})
+}
+
+// searchTables shares filtering, echo exclusion, RRF and pagination between
+// ordinary lexical queries and opt-in relaxation. Query syntax stays private.
+func searchTables(opts models.SearchOptions, search func(string, models.SearchOptions) ([]SearchResult, error)) ([]SearchResult, error) {
+	if opts.ContentType == "tool" {
+		return search("tool_fts", opts)
 	}
+	if opts.ContentType != "" {
+		return search("messages_fts", opts)
+	}
+	candidates := func(table string) ([]SearchResult, error) {
+		return refillCandidatesWithoutDirectEchoes(withoutPaging(opts), func(page models.SearchOptions) ([]SearchResult, error) {
+			return search(table, page)
+		})
+	}
+	prose, err := candidates("messages_fts")
+	if err != nil {
+		return nil, err
+	}
+	tool, err := candidates("tool_fts")
+	if err != nil {
+		return nil, err
+	}
+	return paginate(mergeRRF(prose, tool), opts.Limit, opts.Offset), nil
 }
 
 // searchTable queries a single FTS table with all filters applied.
@@ -71,6 +79,11 @@ func (d *Database) searchTable(ftsTable, query string, opts models.SearchOptions
 		ftsQuery = sanitizeFTS5Query(query, stopwords)
 	}
 
+	return d.searchTableQuery(ftsTable, ftsQuery, opts)
+}
+
+// searchTableQuery accepts only internally compiled MATCH expressions.
+func (d *Database) searchTableQuery(ftsTable, ftsQuery string, opts models.SearchOptions) ([]SearchResult, error) {
 	// Build WHERE clause for filters
 	var whereClauses []string
 	var args []interface{}
@@ -328,12 +341,6 @@ func withoutPaging(o models.SearchOptions) models.SearchOptions {
 	o.Limit = unfilteredSearchCandidateLimit
 	o.Offset = 0
 	return o
-}
-
-func (d *Database) searchCandidatesWithoutDirectEchoes(table, query string, opts models.SearchOptions) ([]SearchResult, error) {
-	return refillCandidatesWithoutDirectEchoes(opts, func(page models.SearchOptions) ([]SearchResult, error) {
-		return d.searchTable(table, query, page)
-	})
 }
 
 func refillCandidatesWithoutDirectEchoes(opts models.SearchOptions, loadPage func(models.SearchOptions) ([]SearchResult, error)) ([]SearchResult, error) {


### PR DESCRIPTION
## What

Add explicit `backscroll search --relax` for bounded lexical recall. Ordinary searches and `--relax=false` retain existing behavior and result output.

Closes #66.

## Why

Strict implicit AND can hide an indexed target when a conversational query adds an unrelated term. The native regression retains the tracked `violet handshake` target and adds independent distractors containing `adaptation`: strict search returns no rows; the opt-in search drops that common term and returns the exact target with provenance.

The existing synthetic conversational cases have no surviving target vocabulary overlap. Their manual refinement introduces new words, so they are not used to claim a lexical-relaxation improvement.

## How

- `internal/storage/relaxation.go`: strict first, then drop lowest-IDF unprotected terms one at a time after zero eligible rows. Actual MATCH document counts establish IDF order; ties follow query order. Stop before fewer than two distinct unprotected terms remain.
- Protect leading `+term` and quoted phrases. Protected-query/drop stages bypass dynamic stopwords to keep those units intact. Unmarked strict matches retain the original sanitizer and snippets.
- Reuse existing scope filters, echo exclusion, RRF and pagination. Never widen project/source-path/content-type or other filters; never use global OR. Exhausted pages and output truncation do not trigger extra stages.
- Emit `match_stage` and cumulative `dropped_terms` for relaxed results in robot, human and JSON output. Robot provenance shares each result's token budget. Empty replies identify attempted stages on stderr.
- Document syntax, scope, stopword behavior and no-overlap limits in `docs/search.md`; update skill usage guidance and record the approved contract in ADR 0009.

No embeddings, default change, stopword rewrite, schema migration, single-term fallback or production-latency claim.

## Validation

- RED → GREEN: `go test ./cmd/backscroll -run '^TestSearchRelaxationRecoverableE2E$' -count=1` failed on the missing opt-in flag before implementation and passes with exact-target/provenance assertions.
- `go test ./... -race -coverprofile=...` passed with scrubbed HOME/config.
- `just ci` passed; aggregate statement coverage **86.5%**.
- `just check` passed.
- Skill installer/installed-recipe suite: **19 tests passed**.
- Independent native binaries: **105 query/format/scope combinations** matched exit status, stdout and stderr byte-for-byte between base `24779f35a74e8753e298f5c14ef548ba80986f64`, this implementation, and `--relax=false`.
- `scripts/eval.sh --dataset synthetic --verbose` on `b034a6c457c7915c2a55a2b05b13ada67dc9f3c0`: unchanged default recall@5 **5/7**, bounded reachability **4/7**, zero unexpected execution failures.
- Staged secret scan: no leaks.

## Checklist

- [x] Tests pass (`just ci`, full race suite)
- [x] Code is clean (`just check`)
- [x] Snapshots updated if needed — not applicable; Go CLI, no Rust snapshot changes
- [x] Changes are documented if user-facing

Remote CI has not yet been evaluated; local validation above is not a claim of green remote checks.
