### PR TITLE
fix(tests): stop test-install.sh from leaking its fixture into real HOME

### DIFF
--- a/tests/test-install-isolation.sh
+++ b/tests/test-install-isolation.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regression for issue #74: tests/test-install.sh must never leak its
+# FAKE_BINARY fixture into a real caller's $HOME/.local/bin. The suite is
+# supposed to establish its own BACKSCROLL_INSTALL_DIR/BACKSCROLL_CONFIG_DIR
+# overrides before install.sh is sourced or invoked — never after.
+#
+# This drives the real suite (unmodified) against a synthetic caller HOME
+# with no BACKSCROLL_INSTALL_DIR/BACKSCROLL_CONFIG_DIR/BACKSCROLL_INPUTS_SOURCE_DIR
+# inherited from this process — i.e. today's ordinary, unwrapped invocation —
+# and asserts the synthetic HOME's default binary location is left untouched:
+# byte- and mode-preserved when a binary already exists there, still absent
+# when it does not. All writes are contained to per-scenario temp directories;
+# the real $HOME is never used as a target.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SUITE="$SCRIPT_DIR/tests/test-install.sh"
+
+pass() {
+    ((PASS++))
+    echo "  PASS: $1"
+}
+fail() {
+    ((FAIL++))
+    echo "  FAIL: $1 — $2"
+}
+
+file_mode() {
+    stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
+}
+
+# Runs the real installation suite against a synthetic HOME, with no
+# BACKSCROLL_INSTALL_DIR/BACKSCROLL_CONFIG_DIR/BACKSCROLL_INPUTS_SOURCE_DIR
+# inherited from this process — reproducing an ordinary caller invocation.
+run_suite_against_home() {
+    local synthetic_home="$1" log="$2"
+    env -u BACKSCROLL_INSTALL_DIR -u BACKSCROLL_CONFIG_DIR -u BACKSCROLL_INPUTS_SOURCE_DIR \
+        HOME="$synthetic_home" \
+        bash "$SUITE" >"$log" 2>&1
+}
+
+echo "=== install.sh test-suite isolation regression (issue #74) ==="
+
+# Scenario: a pre-existing default binary must be byte- and mode-preserved.
+echo "[default binary preserved when one already exists]"
+SYN_HOME=$(mktemp -d)
+LOG=$(mktemp)
+mkdir -p "$SYN_HOME/.local/bin"
+TARGET="$SYN_HOME/.local/bin/backscroll"
+printf '#!/bin/sh\nprintf "ORIGINAL_BINARY\\n"\n' >"$TARGET"
+chmod 755 "$TARGET"
+ORIGINAL_COPY=$(mktemp)
+cp -p "$TARGET" "$ORIGINAL_COPY"
+
+run_suite_against_home "$SYN_HOME" "$LOG" || true
+
+if [ -e "$TARGET" ] && cmp -s "$ORIGINAL_COPY" "$TARGET" && [ "$(file_mode "$TARGET")" = "755" ]; then
+    pass "pre-existing default binary is byte- and mode-preserved"
+else
+    fail "pre-existing default binary preservation" "suite log tail: $(tail -5 "$LOG")"
+fi
+rm -rf "$SYN_HOME" "$ORIGINAL_COPY" "$LOG"
+
+# Scenario: no default binary must appear when none existed before.
+echo "[no default binary appears when absent]"
+SYN_HOME=$(mktemp -d)
+LOG=$(mktemp)
+TARGET="$SYN_HOME/.local/bin/backscroll"
+
+run_suite_against_home "$SYN_HOME" "$LOG" || true
+
+if [ ! -e "$TARGET" ]; then
+    pass "no default binary is created when none existed"
+else
+    fail "default binary should stay absent" "found $(stat -f '%z bytes, mode %Lp' "$TARGET" 2>/dev/null || stat -c '%s bytes, mode %a' "$TARGET")"
+fi
+rm -rf "$SYN_HOME" "$LOG"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -104,6 +104,9 @@ fi
 echo "[Linux x86_64 detection]"
 testable=$(make_testable)
 output=$(bash -c "
+    export BACKSCROLL_INSTALL_DIR=\$(mktemp -d)
+    export BACKSCROLL_CONFIG_DIR=\$(mktemp -d)
+    export BACKSCROLL_INPUTS_SOURCE_DIR='$INPUTS_DIR'
     source '$testable'
     uname() {
         case \"\$1\" in
@@ -128,9 +131,6 @@ output=$(bash -c "
         fi
     }
     chmod() { :; }
-    export BACKSCROLL_INSTALL_DIR=\$(mktemp -d)
-    export BACKSCROLL_CONFIG_DIR=\$(mktemp -d)
-    export BACKSCROLL_INPUTS_SOURCE_DIR='$INPUTS_DIR'
     main 2>&1
 ") && rc=$? || rc=$?
 rm -f "$testable"
@@ -145,6 +145,9 @@ fi
 echo "[macOS arm64 detection]"
 testable=$(make_testable)
 output=$(bash -c "
+    export BACKSCROLL_INSTALL_DIR=\$(mktemp -d)
+    export BACKSCROLL_CONFIG_DIR=\$(mktemp -d)
+    export BACKSCROLL_INPUTS_SOURCE_DIR='$INPUTS_DIR'
     source '$testable'
     uname() {
         case \"\$1\" in
@@ -169,9 +172,6 @@ output=$(bash -c "
         fi
     }
     chmod() { :; }
-    export BACKSCROLL_INSTALL_DIR=\$(mktemp -d)
-    export BACKSCROLL_CONFIG_DIR=\$(mktemp -d)
-    export BACKSCROLL_INPUTS_SOURCE_DIR='$INPUTS_DIR'
     main 2>&1
 ") && rc=$? || rc=$?
 rm -f "$testable"


### PR DESCRIPTION
## Summary

A prior 60-minute bounded scout (`data/bs-fixture-leak-spike-r1/report.md`, at revision `24779f35`) reproduced and root-caused #74: `tests/test-install.sh` sources `install.sh` — which eagerly computes `INSTALL_DIR="${BACKSCROLL_INSTALL_DIR:-${HOME}/.local/bin}"` at source time — *before* the "Linux x86_64 detection" and "macOS arm64 detection" tests export their own `BACKSCROLL_INSTALL_DIR` override (`tests/test-install.sh:107/131` and `:148/172` at that revision). Running the unwrapped suite therefore installs its 12-byte, mode-0644, non-executable `FAKE_BINARY` fixture straight into the caller's real `$HOME/.local/bin/backscroll`, silently replacing (or shadowing) any real installed binary — while the suite still reports `14/14 passed`, because its own assertions check the printed asset-name text rather than the actual destination or preservation of a pre-existing file there.

This PR implements the report's recommended follow-up:

- Moves the `BACKSCROLL_INSTALL_DIR` / `BACKSCROLL_CONFIG_DIR` / `BACKSCROLL_INPUTS_SOURCE_DIR` exports **before** `source '$testable'` in both the Linux and Darwin detection tests, so `INSTALL_DIR` is computed against the override rather than the ambient `HOME`. No other test coverage (explicit-override tests, platform-default-resolution tests) was weakened or removed.
- Adds `tests/test-install-isolation.sh`: a versioned regression that drives the real, unmodified suite against a synthetic caller `HOME` with **no** install/config overrides pre-exported (today's ordinary, unwrapped invocation shape), and asserts the synthetic `HOME`'s default binary location is byte- and mode-preserved when one already exists, and stays absent when it does not. All writes are contained to per-scenario temp directories; the real `$HOME` is never used as a target.

This is a **test-harness isolation fix only** — no product `install.sh` runtime behavior changes for a correctly-ordered caller (e.g. `run_main_linux`, which already exported before sourcing).

## Evidence

- RED commit (fix stashed, regression run against the unfixed suite): both isolation assertions failed while the suite itself still reported `14/14 passed, 0 failed`:
  ```
  [default binary preserved when one already exists]
    FAIL: pre-existing default binary preservation — ...
  [no default binary appears when absent]
    FAIL: default binary should stay absent — found 12 bytes, mode 644

  Results: 0 passed, 2 failed
  ```
- GREEN commit (this PR, `6e52e87`): regression passes and all existing tests still pass:
  ```
  $ bash tests/test-install-isolation.sh
  Results: 2 passed, 0 failed

  $ bash tests/test-install.sh
  Results: 14 passed, 0 failed
  ```
- `gofmt -l .` clean, `go vet ./...` clean. No `.go` files touched, so the `just ci` coverage gate is not implicated.

## Test plan

- [x] `bash tests/test-install-isolation.sh` — RED verified against unfixed suite, GREEN against this fix
- [x] `bash tests/test-install.sh` — all 14 existing tests still pass
- [x] `gofmt -l .` / `go vet ./...` clean

Closes #74