### PR TITLE
fix(search): rank strongest bm25 match first and keep it inside the candidate window

### DIFF
--- a/cmd/backscroll/query_echo_e2e_test.go
+++ b/cmd/backscroll/query_echo_e2e_test.go
@@ -23,6 +23,7 @@ type queryEchoResult struct {
 	Content     string
 	ContentType string
 	Rank        int
+	Score       float64
 }
 
 type queryEchoE2E struct {
@@ -42,16 +43,16 @@ func TestDirectBackscrollSearchEchoesDoNotCrowdUnfilteredRecall(t *testing.T) {
 
 	baseline := e.searchJSON(queryEchoText, "", 20)
 	wantBaseline := []string{
-		"decoy-2.jsonl:text:1",
+		"decoy-0.jsonl:text:1",
 		"decoy-1.jsonl:text:2",
-		"decoy-0.jsonl:text:3",
+		"decoy-2.jsonl:text:3",
 		"target.jsonl:text:4",
 	}
 	if got := queryEchoShape(baseline); !reflect.DeepEqual(got, wantBaseline) {
 		t.Fatalf("four-prose baseline must put target at rank 4\ngot:  %v\nwant: %v", got, wantBaseline)
 	}
-	baselineBudgets := e.budgetReachability(queryEchoText, []int{150, 160, 170, 180, 190, 200, 210})
-	wantBaselineBudgets := map[int]bool{150: false, 160: true, 170: true, 180: true, 190: true, 200: true, 210: true}
+	baselineBudgets := e.budgetReachability(queryEchoText, []int{110, 120, 130, 140, 150, 160, 170})
+	wantBaselineBudgets := map[int]bool{110: false, 120: false, 130: false, 140: true, 150: true, 160: true, 170: true}
 	if !reflect.DeepEqual(baselineBudgets, wantBaselineBudgets) {
 		t.Fatalf("unexpected no-echo budget baseline: got %v want %v", baselineBudgets, wantBaselineBudgets)
 	}
@@ -73,8 +74,8 @@ func TestDirectBackscrollSearchEchoesDoNotCrowdUnfilteredRecall(t *testing.T) {
 	if got := queryEchoFiles(e.searchJSON(queryEchoText, "tool", 20)); !reflect.DeepEqual(got, wantEchoes) {
 		t.Errorf("explicit tool search must retain exact echo identities: got %v want %v", got, wantEchoes)
 	}
-	if got := e.budgetReachability(queryEchoText, []int{150, 160, 170, 180, 190, 200, 210}); !reflect.DeepEqual(got, wantBaselineBudgets) {
-		t.Errorf("query echoes changed bounded baseline, including focal budget 180: got %v want %v", got, wantBaselineBudgets)
+	if got := e.budgetReachability(queryEchoText, []int{110, 120, 130, 140, 150, 160, 170}); !reflect.DeepEqual(got, wantBaselineBudgets) {
+		t.Errorf("query echoes changed bounded baseline, including focal budget 140: got %v want %v", got, wantBaselineBudgets)
 	}
 	if repeat := queryEchoShape(e.searchJSON(queryEchoText, "", 20)); !reflect.DeepEqual(repeat, wantBaseline) {
 		t.Errorf("repeat must preserve corrected deterministic order: got %v want %v", repeat, wantBaseline)
@@ -108,8 +109,10 @@ func TestDirectBackscrollSearchEchoesDoNotCrowdUnfilteredRecall(t *testing.T) {
 func TestDirectBackscrollSearchEchoesRefillToolCandidateWindow(t *testing.T) {
 	e := newQueryEchoE2E(t)
 	query := "overflow scarlet zebra"
+	// The legitimate command is deliberately the longest (weakest bm25) match so
+	// it sits at the end of the candidate window behind every echo.
 	legitimatePath := e.writeRecord("overflow-legitimate.jsonl", "overflow-legitimate", "overflow", 0,
-		queryEchoToolBlock("overflow-legitimate", "rg '"+query+"' /synthetic"), false)
+		queryEchoToolBlock("overflow-legitimate", "rg '"+query+"' /synthetic --glob '*.go' --glob '*.md' --hidden --no-ignore --max-columns 200 --context 3 --sort path"), false)
 	e.run("status", "--json")
 
 	if got := queryEchoRank(e.searchJSON(query, "", 300), filepath.Base(legitimatePath)); got != 1 {
@@ -217,11 +220,14 @@ func newQueryEchoE2E(t *testing.T) *queryEchoE2E {
 func (e *queryEchoE2E) writeCoreProse() []string {
 	e.t.Helper()
 	var paths []string
+	// Decoys repeat the query densely so they legitimately outrank the target;
+	// the target is the weakest genuine prose match and sits at rank 4, where
+	// query echoes could crowd it out of a short page.
 	for i := 0; i < 3; i++ {
-		content := "We asked about " + queryEchoText + ". No answer yet. " + strings.Repeat("Unrelated planning notes. ", 10+i*10)
+		content := "We asked about " + queryEchoText + ". " + queryEchoText + " again. " + strings.Repeat("Unrelated planning notes. ", 1+i)
 		paths = append(paths, e.writeRecord(fmt.Sprintf("decoy-%d.jsonl", i), fmt.Sprintf("decoy-%d", i), fmt.Sprintf("decoy-%d", i), i, content, false))
 	}
-	paths = append(paths, e.writeRecord("target.jsonl", "target", "historical-target", 3, queryEchoText+": readers use the last committed SQLite snapshot.", false))
+	paths = append(paths, e.writeRecord("target.jsonl", "target", "historical-target", 3, queryEchoText+": readers use the last committed SQLite snapshot. "+strings.Repeat("Unrelated planning notes. ", 10), false))
 	return paths
 }
 

--- a/cmd/backscroll/search_ranking_e2e_test.go
+++ b/cmd/backscroll/search_ranking_e2e_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestSearchRanksStrongestBM25MatchFirst is the regression test for issue #77.
+// FTS5 bm25() is lower-is-better (negative); the SQL previously sorted DESC,
+// so the weakest match ranked first on every path and, once matches exceeded
+// the page or candidate cap, the best matches were dropped entirely.
+//
+// The fixture needs enough non-matching documents that IDF stays positive:
+// when the term appears in most documents FTS5 clamps IDF to ~0, every match
+// ties near -0.000, and the inversion hides behind the tie.
+func TestSearchRanksStrongestBM25MatchFirst(t *testing.T) {
+	e := newQueryEchoE2E(t)
+	filler := strings.Repeat("filler alpha beta gamma delta ", 60)
+
+	e.writeRecord("strong.jsonl", "strong", "strong", 0, "widget widget widget widget", false)
+	e.writeRecord("medium.jsonl", "medium", "medium", 1, "the widget was assembled by the team after lunch with some coffee and a long discussion about the schedule", false)
+	e.writeRecord("weak.jsonl", "weak", "weak", 2, "widget "+filler, false)
+	e.writeRecord("strong-tool.jsonl", "strong-tool", "strong-tool", 3, queryEchoToolBlock("strong-tool", "sprocket sprocket sprocket sprocket"), false)
+	e.writeRecord("weak-tool.jsonl", "weak-tool", "weak-tool", 4, queryEchoToolBlock("weak-tool", "sprocket --flag one --flag two --flag three --flag four --flag five --flag six --flag seven --flag eight --flag nine --flag ten --flag eleven --flag twelve"), false)
+	for i := 0; i < 20; i++ {
+		e.writeRecord("nonmatch.jsonl", fmt.Sprintf("nonmatch-%02d", i), "nonmatch", 5+i, fmt.Sprintf("unrelated note %d about the weather and the deploy schedule with nothing else", i), i > 0)
+		e.writeRecord("nonmatch-tool.jsonl", fmt.Sprintf("nonmatch-tool-%02d", i), "nonmatch-tool", 5+i, queryEchoToolBlock(fmt.Sprintf("nonmatch-tool-%02d", i), fmt.Sprintf("echo unrelated tool call %d", i)), i > 0)
+	}
+	e.run("status", "--json")
+
+	wantProse := []string{"strong.jsonl", "medium.jsonl", "weak.jsonl"}
+	wantTool := []string{"strong-tool.jsonl", "weak-tool.jsonl"}
+
+	textOnly := e.searchJSON("widget", "text", 20)
+	if got := rankedFiles(textOnly); !reflect.DeepEqual(got, wantProse) {
+		t.Errorf("--content-type text order = %v, want %v", got, wantProse)
+	}
+	assertAscendingNonPositiveScores(t, "--content-type text", e.searchScores("widget", "text", 20))
+
+	toolOnly := e.searchJSON("sprocket", "tool", 20)
+	if got := rankedFiles(toolOnly); !reflect.DeepEqual(got, wantTool) {
+		t.Errorf("--content-type tool order = %v, want %v", got, wantTool)
+	}
+	assertAscendingNonPositiveScores(t, "--content-type tool", e.searchScores("sprocket", "tool", 20))
+
+	// The unfiltered path fuses both tables by rank position (RRF), so it must
+	// inherit the corrected order without any change of its own.
+	if got := rankedFiles(e.searchJSON("widget", "", 20)); !reflect.DeepEqual(got, wantProse) {
+		t.Errorf("unfiltered RRF prose order = %v, want %v", got, wantProse)
+	}
+	if got := rankedFiles(e.searchJSON("sprocket", "", 20)); !reflect.DeepEqual(got, wantTool) {
+		t.Errorf("unfiltered RRF tool order = %v, want %v", got, wantTool)
+	}
+	if got := rankedFiles(e.searchJSON("widget", "text", 1)); !reflect.DeepEqual(got, wantProse[:1]) {
+		t.Errorf("--limit 1 must return the strongest match, got %v", got)
+	}
+
+	// Candidate cap: 230 matches weaker than weak.jsonl push the prose match
+	// count past the unfiltered 200-candidate window. The strongest documents
+	// must still lead instead of falling off the end of the window.
+	longFiller := strings.Repeat("pad alpha beta gamma delta ", 80)
+	for i := 0; i < 230; i++ {
+		e.writeRecord("weak-many.jsonl", fmt.Sprintf("weak-many-%03d", i), "weak-many", 25, fmt.Sprintf("widget once in a very long note %d ", i)+longFiller, i > 0)
+	}
+	for i := 0; i < 300; i++ {
+		e.writeRecord("nonmatch-many.jsonl", fmt.Sprintf("nonmatch-many-%03d", i), "nonmatch-many", 26, fmt.Sprintf("nonmatching note %d about the weather and the deploy schedule with nothing else here", i), i > 0)
+	}
+	e.run("status", "--json")
+
+	capped := e.searchJSON("widget", "", 300)
+	if len(capped) != 200 {
+		t.Fatalf("unfiltered candidate window returned %d results, want 200", len(capped))
+	}
+	if got := rankedFiles(capped)[:3]; !reflect.DeepEqual(got, wantProse) {
+		t.Errorf("unfiltered top three past the candidate cap = %v, want %v", got, wantProse)
+	}
+	full := e.searchJSON("widget", "text", 300)
+	if len(full) != 233 {
+		t.Fatalf("--content-type text returned %d results, want 233", len(full))
+	}
+	if got := rankedFiles(full)[:3]; !reflect.DeepEqual(got, wantProse) {
+		t.Errorf("--content-type text top three = %v, want %v", got, wantProse)
+	}
+	if got := rankedFiles(e.searchJSON("widget", "text", 10)); !reflect.DeepEqual(got[:3], wantProse) {
+		t.Errorf("default-sized page must lead with the strongest matches, got %v", got)
+	}
+	if repeat := e.searchJSON("widget", "", 300); !reflect.DeepEqual(repeat, capped) {
+		t.Errorf("repeat unfiltered query changed order across the candidate refill loop")
+	}
+}
+
+// rankedFiles returns fixture file names in result order (queryEchoFiles sorts).
+func rankedFiles(results []queryEchoResult) []string {
+	files := make([]string, 0, len(results))
+	for _, result := range results {
+		files = append(files, filepath.Base(result.FilePath))
+	}
+	return files
+}
+
+func (e *queryEchoE2E) searchScores(query, contentType string, limit int) []float64 {
+	e.t.Helper()
+	results := e.searchJSON(query, contentType, limit)
+	scores := make([]float64, len(results))
+	for i, result := range results {
+		scores[i] = result.Score
+	}
+	return scores
+}
+
+func assertAscendingNonPositiveScores(t *testing.T, label string, scores []float64) {
+	t.Helper()
+	for i, score := range scores {
+		if score > 0 {
+			t.Errorf("%s result %d score %.4f > 0; bm25 scores are never positive", label, i+1, score)
+		}
+		if i > 0 && score < scores[i-1] {
+			t.Errorf("%s result %d score %.4f is better than result %d score %.4f; results must be best-first", label, i+1, score, i, scores[i-1])
+		}
+	}
+}

--- a/docs/search.md
+++ b/docs/search.md
@@ -3,7 +3,7 @@ estado: Completed
 ---
 # Search Engine
 
-The search command performs full-text search across all indexed sessions using BM25 relevance ranking. Results include highlighted snippets showing where the query matched. `--source-path` is a filter: every executable search example must include positional query text or `--text <query>`.
+The search command performs full-text search across all indexed sessions using BM25 relevance ranking. Results include highlighted snippets showing where the query matched. Results are always best-first: rank 1 is the strongest match. For a `--content-type` search the `Score`/`score` field is the raw FTS5 `bm25()` value, which is zero or negative with a more negative value meaning a better match, so rows are ordered by ascending score with row id as a deterministic tiebreaker. An unfiltered search merges the prose and tool indexes by rank position and reports the positive Reciprocal Rank Fusion score instead, where higher is better. `--source-path` is a filter: every executable search example must include positional query text or `--text <query>`.
 
 ## CLI Usage
 
@@ -36,7 +36,7 @@ Human-readable output with terminal bold for match highlights. Each result uses 
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Rank: 1 | Source: session | Role: assistant | Score: 12.34
+Rank: 1 | Source: session | Role: assistant | Score: -3.63
 Path: /home/user/.claude/projects/backscroll/sessions/abc123/session.jsonl
 ...the migration plan involves three phases...
 ```
@@ -49,7 +49,7 @@ Match markers (`>>>` and `<<<` in the raw snippet) are rendered as bold text in 
 
 ```json
 [
-  {"source_path": "~/.claude/.../session.jsonl", "snippet": "...matched text...", "score": 12.34, "role": "assistant", "timestamp": "2026-08-20T12:34:56Z"}
+  {"source_path": "~/.claude/.../session.jsonl", "snippet": "...matched text...", "score": -3.63, "role": "assistant", "timestamp": "2026-08-20T12:34:56Z"}
 ]
 ```
 
@@ -65,7 +65,7 @@ With `--fields full`, ordinary results encode the existing `models.SearchResult`
     "Timestamp": "2026-08-20T12:34:56Z",
     "SessionID": "",
     "ProjectPath": "backscroll",
-    "Score": 12.34,
+    "Score": -3.63,
     "Tags": null,
     "ContentType": "text",
     "Rank": 1
@@ -83,7 +83,7 @@ Robot mode emits deterministic `result_N_field=value` lines. Like JSON,
 ```
 result_0_filepath=/home/user/.claude/projects/example/session.jsonl
 result_0_content=bounded matched snippet
-result_0_score=12.34
+result_0_score=-3.63
 result_0_role=assistant
 result_0_timestamp=2026-08-20T12:34:56Z
 ```
@@ -99,7 +99,7 @@ result_0_content=complete content with escaped newlines
 result_0_project=backscroll
 result_0_content_type=text
 result_0_timestamp=2026-08-20T12:34:56Z
-result_0_score=12.34
+result_0_score=-3.63
 result_0_rank=1
 ```
 

--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -179,7 +179,7 @@ func (d *Database) searchTableQuery(ftsTable, ftsQuery string, opts models.Searc
 		JOIN search_items si ON %[1]s.rowid = si.id
 		%[2]s
 		%[3]s
-		ORDER BY score DESC
+		ORDER BY score ASC, si.id ASC -- bm25() is lower-is-better; si.id keeps LIMIT/OFFSET pages stable
 		LIMIT ? OFFSET ?
 	`, ftsTable, tagJoin, whereSQL)
 


### PR DESCRIPTION
## What

Sort lexical search results by ascending `bm25()` with `si.id` as a deterministic tiebreaker, so rank 1 is the strongest match on every path and the best matches stay inside the page and candidate window.

## Why

Closes #77.

SQLite FTS5 `bm25()` is lower-is-better (negative). `internal/storage/search.go` sorted `ORDER BY score DESC` since the initial storage commit (`9280dd2`), so every lexical path returned the weakest match at rank 1: `--content-type text|code|reasoning|tool`, the unfiltered RRF merge (`mergeRRF` fuses by rank position and inherits its inputs' order), the vector RRF path in `internal/storage/hybrid.go:73-82`, and every relaxation stage.

Because `LIMIT` ran after the inverted sort, this was recall loss, not only misordering. Reproduced on a dev build with a native-ingest fixture (233 prose matches, IDF positive):

- `search --text widget --all-projects --limit 300` (unfiltered, 200-candidate window at `search.go:336`) returned 200 rows with the three strongest documents absent entirely.
- `search --text widget --content-type text --limit 300` returned them at ranks 231, 232, 233; raw `sqlite3 ... ORDER BY bm25(messages_fts) ASC` puts the same rows first (-2.291, -1.705, -0.658).

## How

- `internal/storage/search.go:182`: `ORDER BY score ASC, si.id ASC`. The id tiebreaker gives `refillCandidatesWithoutDirectEchoes` a total order so its repeated `LIMIT/OFFSET` pages cannot duplicate or skip tied rows.
- No change to `mergeRRF`, `hybrid.go`, or `relaxation.go`: they consume positional order. Verified in the new test: the unfiltered path returns `strong, medium, weak` and `strong-tool, weak-tool` after the fix without touching those files.
- `cmd/backscroll/search_ranking_e2e_test.go` (new): native regression test with enough non-matching documents that IDF stays positive (with the term in most documents FTS5 clamps IDF to ~0 and every score ties at -0.000, which is why small fixtures never showed this). Asserts best-first order and non-positive monotonic scores for `--content-type text`, `--content-type tool`, both unfiltered RRF merges, `--limit 1`, and a 233-match corpus past the 200-candidate window where the top three must still lead.
- `cmd/backscroll/query_echo_e2e_test.go`: the two query-echo E2E fixtures were shaped for the inverted order. The four-prose baseline now repeats the query in the decoys so the historical target is still the weakest genuine match at rank 4 (where echoes could crowd it), and the overflow test's legitimate command is now the longest tool match so it still sits at the end of the candidate window. Token-budget focal point moved from 180 to 140 because the decoy snippets are shorter (measured threshold between 130 and 135 tokens).
- `docs/search.md`: example scores were shown as `12.34`; real output is never positive on a `--content-type` search. Replaced with `-3.63` and documented the sign convention, including that an unfiltered search reports the positive RRF score instead.

Output-shape impact: the `Score` field's values are unchanged in sign and scale; only the order of results changes. Consumers that assumed rank 1 was the best match were getting the worst one.

## Checklist

- [x] Tests pass (`just test`) — also `just ci` (coverage 86.5%) and `go test ./... -race` with scrubbed `HOME`
- [x] Code is clean (`just check`)
- [ ] Snapshots updated if needed (`cargo insta review`) — n/a, Go implementation has no insta snapshots
- [x] Changes are documented if user-facing (`docs/search.md`)
