### PR TITLE
perf(search): count unfiltered --relax IDF in SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Ten v2 CLI commands: `list [--project] [--all-projects] [--recent N] [--order ti
 
 The `SearchEngine` interface is the port; `internal/storage` is the adapter. Database opened lazily. `OpenReadOnly()` provides read-only access for external consumers.
 
-Opt-in lexical term dropping is owned by `internal/storage/relaxation.go`; `docs/search.md#opt-in-lexical-relaxation` defines protected units, the two-unprotected-term floor, fixed scope, provenance and zero-overlap limits. Unfiltered IDF uses the same query-echo eligibility as unfiltered result pages. Ordinary search behavior/output must remain unchanged.
+Opt-in lexical term dropping is owned by `internal/storage/relaxation.go`; `docs/search.md#opt-in-lexical-relaxation` defines protected units, the two-unprotected-term floor, fixed scope, provenance and zero-overlap limits. Unfiltered IDF uses the same query-echo eligibility as unfiltered result pages, counted in SQL via `directBackscrollSearchEchoSQL` (keep lockstep with `isDirectBackscrollSearchEcho`; do not reintroduce a Go-side row scan). Ordinary search behavior/output must remain unchanged.
 
 ### Core Pipeline
 

--- a/internal/storage/relaxation.go
+++ b/internal/storage/relaxation.go
@@ -217,25 +217,12 @@ func (d *Database) recallFrequency(term recallTerm, contentType string) (int, er
 		}
 		return count, nil
 	}
-	rows, err := d.db.Query("SELECT si.content_type, COALESCE(si.search_echo, 0), si.text FROM ("+matched+") matched JOIN search_items si ON si.id = matched.rowid", args...)
-	if err != nil {
-		return 0, fmt.Errorf("measure relaxation term frequency: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
 	var count int
-	for rows.Next() {
-		var result SearchResult
-		var echo int
-		if err := rows.Scan(&result.ContentType, &echo, &result.Text); err != nil {
-			return 0, fmt.Errorf("measure relaxation term frequency: %w", err)
-		}
-		result.SearchEcho = echo != 0
-		if isDirectBackscrollSearchEcho(result) {
-			continue
-		}
-		count++
-	}
-	if err := rows.Err(); err != nil {
+	err := d.db.QueryRow(
+		"SELECT COUNT(*) FROM ("+matched+") matched JOIN search_items si ON si.id = matched.rowid WHERE NOT ("+directBackscrollSearchEchoSQL("si")+")",
+		args...,
+	).Scan(&count)
+	if err != nil {
 		return 0, fmt.Errorf("measure relaxation term frequency: %w", err)
 	}
 	return count, nil

--- a/internal/storage/relaxation_echo_idf_test.go
+++ b/internal/storage/relaxation_echo_idf_test.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/pablontiv/backscroll/internal/models"
 )
@@ -208,4 +210,187 @@ func TestRelaxationUnfilteredIDFTreatsEchoOnlyTermsAsAbsent(t *testing.T) {
 	if fmt.Sprint(stages) != "[strict drop-terms/1]" {
 		t.Fatalf("expected one drop of a real term before the two-term floor: stages=%v", stages)
 	}
+}
+
+func TestRecallFrequencySQLEchoPredicatePreservesBoundaries(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	type row struct {
+		name        string
+		contentType string
+		text        string
+		echo        bool
+		nullEcho    bool
+		unique      string
+		wantEcho    bool
+	}
+	cases := []row{
+		{name: "canonical Bash", contentType: "tool", text: "Bash command=backscroll search --text boundtok00", unique: "boundtok00", wantEcho: true},
+		{name: "lowercase bash", contentType: "tool", text: "bash command=backscroll search --text boundtok01", unique: "boundtok01", wantEcho: true},
+		{name: "path prefix", contentType: "tool", text: "/private/tmp/bin/backscroll search --text boundtok02", unique: "boundtok02"},
+		{name: "command path", contentType: "tool", text: "Bash command=/private/tmp/bin/backscroll search --text boundtok03", unique: "boundtok03"},
+		{name: "env wrapper", contentType: "tool", text: "Bash command=env backscroll search --text boundtok04", unique: "boundtok04"},
+		{name: "bash -lc", contentType: "tool", text: `Bash command=bash -lc "backscroll search --text boundtok05"`, unique: "boundtok05"},
+		{name: "rg", contentType: "tool", text: "Bash command=rg boundtok06 .", unique: "boundtok06"},
+		{name: "status", contentType: "tool", text: "Bash command=backscroll status boundtok07", unique: "boundtok07"},
+		{name: "searcher", contentType: "tool", text: "Bash command=backscroll searcher boundtok08", unique: "boundtok08"},
+		{name: "error prefix", contentType: "tool", text: "error: Bash command=backscroll search failed boundtok09", unique: "boundtok09"},
+		{name: "prose lookalike", contentType: "text", text: "Bash command=backscroll search --text boundtok10", unique: "boundtok10"},
+		{name: "null echo legitimate", contentType: "tool", text: "Bash command=rg boundtok11 /tmp", nullEcho: true, unique: "boundtok11"},
+		{name: "null echo fallback", contentType: "tool", text: "Bash command=backscroll search --text boundtok12", nullEcho: true, unique: "boundtok12", wantEcho: true},
+		{name: "proven echo without prefix", contentType: "tool", text: "Bash command=rg boundtok13 /tmp", echo: true, unique: "boundtok13", wantEcho: true},
+		{name: "uppercase BASH", contentType: "tool", text: "BASH command=backscroll search --text boundtok14", unique: "boundtok14", wantEcho: true},
+		{name: "folded command=", contentType: "tool", text: "Bash Command=backscroll search --text boundtok15", unique: "boundtok15"},
+		{name: "folded Search", contentType: "tool", text: "Bash command=backscroll Search --text boundtok16", unique: "boundtok16"},
+	}
+
+	var files []IndexedFile
+	for i, tc := range cases {
+		files = append(files, IndexedFile{
+			SourcePath: fmt.Sprintf("/bound-%d.jsonl", i), Source: "session", Hash: tc.unique,
+			Messages: []IndexedMessage{{
+				UUID: tc.unique, Role: "assistant", ContentType: tc.contentType,
+				Text: tc.text, SearchEcho: tc.echo,
+			}},
+		})
+	}
+	if err := db.SyncFiles(files); err != nil {
+		t.Fatal(err)
+	}
+	for i, tc := range cases {
+		if !tc.nullEcho {
+			continue
+		}
+		path := fmt.Sprintf("/bound-%d.jsonl", i)
+		if _, err := db.db.Exec("UPDATE search_items SET search_echo = NULL WHERE source_path = ?", path); err != nil {
+			t.Fatalf("null search_echo for %s: %v", tc.name, err)
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result SearchResult
+			var echo int
+			var sqlEcho int
+			err := db.db.QueryRow(
+				"SELECT si.content_type, COALESCE(si.search_echo, 0), si.text, CASE WHEN "+directBackscrollSearchEchoSQL("si")+" THEN 1 ELSE 0 END FROM search_items si WHERE si.uuid = ?",
+				tc.unique,
+			).Scan(&result.ContentType, &echo, &result.Text, &sqlEcho)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result.SearchEcho = echo != 0
+			gotGo := isDirectBackscrollSearchEcho(result)
+			if gotGo != tc.wantEcho {
+				t.Fatalf("Go predicate = %v, want %v (echo=%d text=%q)", gotGo, tc.wantEcho, echo, result.Text)
+			}
+			if (sqlEcho == 1) != tc.wantEcho {
+				t.Fatalf("SQL predicate = %d, want echo=%v (echo=%d text=%q)", sqlEcho, tc.wantEcho, echo, result.Text)
+			}
+
+			got, err := db.recallFrequency(recallTerm{text: tc.unique}, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantDF := 1
+			if tc.wantEcho {
+				wantDF = 0
+			}
+			if got != wantDF {
+				t.Fatalf("unfiltered IDF(%s)=%d, want %d", tc.unique, got, wantDF)
+			}
+		})
+	}
+}
+
+func TestRecallFrequencyUnfilteredSQLMatchesGoScan(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	const n = 8000
+	filler := strings.Repeat("lorem output line about build errors and paths /usr/local/share ", 24)
+	msgs := make([]IndexedMessage, n)
+	for i := 0; i < n; i++ {
+		text := "Bash command=rg commonterm /tmp\n" + filler
+		echo := false
+		if i%10 == 0 {
+			text = "Bash command=backscroll search --text commonterm\n" + filler
+			echo = true
+		}
+		msgs[i] = IndexedMessage{
+			Ordinal: i, UUID: fmt.Sprintf("mix-%d", i), Role: "assistant",
+			ContentType: "tool", Text: text, SearchEcho: echo,
+		}
+	}
+	if err := db.SyncFiles([]IndexedFile{{
+		SourcePath: "/mix.jsonl", Source: "session", Hash: "mix", Messages: msgs,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	term := recallTerm{text: "commonterm"}
+	sqlCount, err := db.recallFrequency(term, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goCount, err := recallFrequencyGoScan(db, term)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sqlCount != goCount {
+		t.Fatalf("SQL IDF=%d Go-scan IDF=%d", sqlCount, goCount)
+	}
+	want := n - n/10
+	if sqlCount != want {
+		t.Fatalf("unfiltered IDF=%d, want %d non-echo rows", sqlCount, want)
+	}
+
+	const rounds = 5
+	sqlStart := time.Now()
+	for i := 0; i < rounds; i++ {
+		if _, err := db.recallFrequency(term, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sqlElapsed := time.Since(sqlStart) / rounds
+	goStart := time.Now()
+	for i := 0; i < rounds; i++ {
+		if _, err := recallFrequencyGoScan(db, term); err != nil {
+			t.Fatal(err)
+		}
+	}
+	goElapsed := time.Since(goStart) / rounds
+	t.Logf("unfiltered IDF n=%d sql=%s go-scan=%s", n, sqlElapsed, goElapsed)
+}
+
+func recallFrequencyGoScan(db *Database, term recallTerm) (int, error) {
+	exprMessages := recallExpression([]recallTerm{term}, "messages_fts")
+	exprTool := recallExpression([]recallTerm{term}, "tool_fts")
+	rows, err := db.db.Query(
+		`SELECT si.content_type, COALESCE(si.search_echo, 0), si.text FROM (
+			SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?
+			UNION
+			SELECT rowid FROM tool_fts WHERE tool_fts MATCH ?
+		) matched JOIN search_items si ON si.id = matched.rowid`,
+		exprMessages, exprTool,
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rows.Close() }()
+	var count int
+	for rows.Next() {
+		var result SearchResult
+		var echo int
+		if err := rows.Scan(&result.ContentType, &echo, &result.Text); err != nil {
+			return 0, err
+		}
+		result.SearchEcho = echo != 0
+		if isDirectBackscrollSearchEcho(result) {
+			continue
+		}
+		count++
+	}
+	return count, rows.Err()
 }

--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -408,6 +408,27 @@ func isDirectBackscrollSearchEcho(result SearchResult) bool {
 	return fields[1] == "command=backscroll" && fields[2] == "search"
 }
 
+// asciiWhitespaceSQL is the ASCII subset of unicode.IsSpace. SQL-side echo
+// matching trims a leading run and treats one separator between tokens.
+const asciiWhitespaceSQL = "char(9, 10, 11, 12, 13, 32)"
+
+// directBackscrollSearchEchoSQL is the SQL equivalent of
+// isDirectBackscrollSearchEcho for the given search_items alias. Keep them in
+// lockstep: tool rows with search_echo != 0, or a three-token prefix of
+// case-insensitive "bash", exact "command=backscroll", exact "search".
+// GLOB is case-sensitive, so only the first token uses a character class;
+// LIKE would fold tokens 2 and 3. The pattern is prefix-only: a lookalike
+// that does not start with that prefix, including path collisions and
+// "searcher", must not match.
+func directBackscrollSearchEchoSQL(alias string) string {
+	trimmed := "ltrim(" + alias + ".text, " + asciiWhitespaceSQL + ")"
+	sep := "'[' || " + asciiWhitespaceSQL + " || ']'"
+	prefix := "'[Bb][Aa][Ss][Hh]' || " + sep + " || 'command=backscroll' || " + sep + " || 'search'"
+	return alias + ".content_type = 'tool' AND (COALESCE(" + alias + ".search_echo, 0) != 0 OR " +
+		trimmed + " GLOB (" + prefix + ") OR " +
+		trimmed + " GLOB (" + prefix + " || " + sep + " || '*'))"
+}
+
 // mergeRRF uses Reciprocal Rank Fusion to merge two ranked lists by position,
 // immune to score-scale differences between tokenizers (trigram vs porter).
 // k=60 is the standard RRF constant.


### PR DESCRIPTION
## What

Unfiltered `--relax` document-frequency counting no longer streams every MATCH row's `text` through Go. Echo exclusion stays the same; only the counting path changes.

## Why

<https://github.com/pablontiv/backscroll/pull/81> made unfiltered IDF use `isDirectBackscrollSearchEcho` so query-echo rows cannot invert which term is dropped. The independent review of that PR (Finding 1) measured the Go-side scan on a 363,145-row production index: a term matching ~91k rows went from 73ms `COUNT(*)` to 1.04s, because the cost is per-row `database/sql` iteration. The same review measured a SQL-side predicate at 227ms with byte-identical counts (~4.5x).

This is that follow-up. Filtered (`contentType != ""`) counting is unchanged: it already uses `COUNT(*)` and must keep echo rows, matching the explicit `--content-type tool` page.

## How

`recallFrequency` (`internal/storage/relaxation.go`) now `COUNT(*)`s the unfiltered MATCH ∪ join with `WHERE NOT (directBackscrollSearchEchoSQL('si'))`.

`directBackscrollSearchEchoSQL` (`internal/storage/search.go`) is the SQL lockstep of `isDirectBackscrollSearchEcho`:

- `content_type = 'tool'`
- `COALESCE(search_echo, 0) != 0`, or
- GLOB three-token prefix: case-insensitive `bash`, exact `command=backscroll`, exact `search`, prefix-only so `/private/tmp/bin/backscroll search`, `env backscroll search`, and `searcher` do not match

GLOB is used instead of LIKE so tokens 2 and 3 stay case-sensitive.

Existing regressions are unmodified: `internal/storage/relaxation_echo_idf_test.go`, `cmd/backscroll/search_relaxation_echo_idf_e2e_test.go`.

New coverage in `TestRecallFrequencySQLEchoPredicatePreservesBoundaries` walks the six `TestExcludeDirectBackscrollSearchEchoesPreservesBoundaries` cases plus prose lookalike (`content_type != 'tool'`), `search_echo IS NULL` legitimate tool text, NULL echo-shaped fallback, proven `search_echo=1` without the prefix, and case-fold probes on tokens 2/3. Each case checks Go predicate, SQL predicate, and unfiltered `recallFrequency`.

`TestRecallFrequencyUnfilteredSQLMatchesGoScan` compares SQL counts to a retained Go-scan helper on 8000 mixed tool rows (10% echo). Counts matched (7200). Timed on this tree (`go test ./internal/storage -run TestRecallFrequencyUnfilteredSQLMatchesGoScan -count=1 -v`): SQL 11.5ms vs Go-scan 31.9ms (~2.8x) with ~1.5KB filler per row. Directional only; the reviewer's 4.5x was on production-scale text volume.

## Checklist

- [x] Tests pass (`go test ./internal/storage -run TestRelaxation`, `go test ./cmd/backscroll -run TestSearchRelaxation`, `go test ./...`)
- [x] Code is clean (`gofmt` on the Go files; `go vet ./internal/storage ./cmd/backscroll`)
- [ ] Snapshots updated if needed (`cargo insta review`) — not applicable (Go)
- [x] Changes are documented if user-facing — behavior unchanged; `AGENTS.md` notes the SQL lockstep so the Go-side scan is not reintroduced

Related: <https://github.com/pablontiv/backscroll/pull/81> (behavior fix). No open duplicate PR.
